### PR TITLE
check if $_REQUEST["edit"]["tt_content"] is set before validating the…

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -169,7 +169,7 @@ if ($json["tt_content"]["elements"]) {
 if (!function_exists('user_mask_contentType')) {
 
 	function user_mask_contentType($param = "") {
-		if (is_array($_REQUEST["edit"]["tt_content"])) {
+		if (isset($_REQUEST["edit"]["tt_content"]) && is_array($_REQUEST["edit"]["tt_content"])) {
 			$field = explode("|", $param);
 			$request = $_REQUEST;
 			$first = array_shift($request["edit"]["tt_content"]);


### PR DESCRIPTION
$_REQUEST["edit"]["tt_content"] is not always set, which results in the following error 
```
TYPO3\CMS\Core\Error\ErrorHandler::handleError(2, "Illegal string offset 'tt_content'", "[path]/typo3conf/ext/mask/ext_localconf.php", 172, array)
```
Happened on 6.2.17 with the Access module