### PR TITLE
Make the CE preview more flexible for Fluid

### DIFF
--- a/Classes/Hooks/PageLayoutViewDrawItem.php
+++ b/Classes/Hooks/PageLayoutViewDrawItem.php
@@ -93,13 +93,11 @@ class PageLayoutViewDrawItem implements \TYPO3\CMS\Backend\View\PageLayoutViewDr
                 $element = $this->storageRepository->loadElement("tt_content", $elementKey);
                 $view->assign("row", $row);
                 $view->assign("data", $data);
+				$view->assign("element", $element);
 
                 // Render everything
-                $content = $view->render();
-                $headerContent = '<strong>' . $element["label"] . '</strong><br>';
-                $itemContent .= '<div style="display:block; padding: 10px 0 4px 0px;border-top: 1px solid #CACACA;margin-top: 6px;" class="content_preview_' . $elementKey . '">';
-                $itemContent .= $content;
-                $itemContent .= '</div>';
+                $itemContent = $parentObject->linkEditContent($view->render(), $row);
+
                 $drawItem = FALSE;
             }
         }


### PR DESCRIPTION
If a template file for the CE preview exists, nearly everything should be rendered by this template to increase flexibility. Then it's for example possible to render the CE icon right before the CE label. Of course there are also other use cases. Perhaps now a default CE preview template would make sense.