### PR TITLE
[FEATURE] Crops and translates the language labels in the backend module

### DIFF
--- a/Classes/ViewHelpers/TranslateLabelViewHelper.php
+++ b/Classes/ViewHelpers/TranslateLabelViewHelper.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MASK\Mask\ViewHelpers;
+
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * View helper that translates a language label, if the result is empty, the label will be returned.
+ *
+ * Example:
+ * {namespace mask=MASK\Mask\ViewHelpers}
+ * <mask:translateLabel key="{key}" />
+ *
+ * @package TYPO3
+ * @subpackage mask
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author Fabian Galinski fabian@sgalinski.de>
+ *
+ */
+class TranslateLabelViewHelper extends AbstractViewHelper {
+	/**
+	 * The given key will be translated. If the result is empty, the key will be returned.
+	 *
+	 * @param string $key
+	 * @param string $extensionName
+	 * @return string
+	 */
+	public function render($key = NULL, $extensionName = NULL) {
+		if (empty($key) || strpos($key, 'LLL') > 0) {
+			return $key;
+		}
+
+		$request = $this->renderingContext->getControllerContext()->getRequest();
+		$extensionName = $extensionName === NULL ? $request->getControllerExtensionName() : $extensionName;
+		$result = LocalizationUtility::translate($key, $extensionName);
+		return (empty($result) ? $key : $result);
+	}
+}
+
+?>

--- a/Resources/Private/Backend/Partials/Forms/General/Form.html
+++ b/Resources/Private/Backend/Partials/Forms/General/Form.html
@@ -5,10 +5,14 @@
 	<!-- field header 3rd column: own/mask fields (eg. tx_mask_text) -->
 	<div class="tx_mask_fieldheader">
 		<div class="tx_mask_fieldheader_icon id_{form}"><core:icon identifier="mask-fieldtype-{form}" size="default" /></div>
-		<div class="tx_mask_fieldheader_text">
-			<h1>{mask:label(elementKey: storage.key, fieldKey: key, field: field, table:type)}</h1>
-			<p>{field.key}</p>
-		</div>
+		<f:alias map="{label: '{mask:label(elementKey: storage.key, fieldKey: key, field: field, table: type)}'}">
+			<div class="tx_mask_fieldheader_text" title="{label}">
+				<h1>
+					<f:format.crop maxCharacters="60" append="..."><mask:translateLabel key="{label}" /></f:format.crop>
+				</h1>
+				<p>{field.key}</p>
+			</div>
+		</f:alias>
 	</div>
 	<div role="tabpanel">
 		<ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-{key}" data-store-last-tab="1">

--- a/Resources/Private/Backend/Partials/Forms/General/Inline.html
+++ b/Resources/Private/Backend/Partials/Forms/General/Inline.html
@@ -7,8 +7,12 @@
 		</div>
 		<div class="tx_mask_btn_text">
 			<span class="id_typetext"><f:translate key="tx_mask.field.{mask:formType(elementKey:'{storage.key}', fieldKey:'{field.key}', type: '{field.inlineParent}')}" /></span>
-			<span class="id_labeltext">{field.label}</span>
-			<span class="id_keytext">{field.key}</span>
+			<span class="id_labeltext" title="{field.label}">
+				<f:format.crop maxCharacters="20" append="..."><mask:translateLabel key="{field.label}" /></f:format.crop>
+			</span>
+			<span class="id_keytext" title="{field.key}">
+				<f:format.crop maxCharacters="20" append="...">{field.key}</f:format.crop>
+			</span>
 		</div>
 		<div class="tx_mask_btn_actions">
 			<span class="id_add" title="{f:translate(key:'tx_mask.field.titleAdd')}"><core:icon identifier="actions-edit-add" size="default" /></span>

--- a/Resources/Private/Backend/Templates/WizardContent/Edit.html
+++ b/Resources/Private/Backend/Templates/WizardContent/Edit.html
@@ -31,17 +31,16 @@
 											</div>
 											<div class="tx_mask_btn_text">
 												<span class="id_typetext"><f:translate key="tx_mask.field.{mask:formType(elementKey:'{storage.key}', fieldKey:'{key}')}" /></span>
-												<span class="id_labeltext"><mask:label elementKey="{storage.key}" fieldKey="{key}" table="tt_content" field="{field}"/></span>
-												<span class="id_keytext">
-													<f:if condition="{field.key}">
-														<f:then>
-															{field.key}
-														</f:then>
-														<f:else>
-															{key}
-														</f:else>
-													</f:if>
-												</span>
+												<f:alias map="{label: '{mask:label(elementKey: \'{storage.key}\', fieldKey: \'{key}\', field: \'{field}\', table: \'tt_content\')}'}">
+													<span class="id_labeltext" title="{label}">
+														<f:format.crop maxCharacters="20" append="..."><mask:translateLabel key="{label}" /></f:format.crop>
+													</span>
+												</f:alias>
+												<f:alias map="{keyText: '{f:if(condition: \'{field.key}\', then: \'{field.key}\', else: \'{key}\')}'}">
+													<span class="id_keytext" title="{keyText}">
+														<f:format.crop maxCharacters="60" append="...">{keyText}</f:format.crop>
+													</span>
+												</f:alias>
 											</div>
 											<div class="tx_mask_btn_actions">
 												<span class="id_add" title="{f:translate(key:'tx_mask.field.titleAdd')}"><core:icon identifier="actions-edit-add" size="default" /></span>
@@ -77,10 +76,12 @@
 											<!-- field header 3rd column: existing/TYPO3 fields (eg. bodytext) -->
 											<div class="tx_mask_fieldheader">
 												<div class="tx_mask_fieldheader_icon id_{mask:formType(elementKey:'{storage.key}', fieldKey:'{key}')}"><core:icon identifier="mask-fieldtype-{mask:formType(elementKey:'{storage.key}', fieldKey:'{key}')}" size="default" /></div>
-												<div class="tx_mask_fieldheader_text">
-													<h1><mask:label elementKey="{storage.key}" fieldKey="{key}" table="tt_content" />&nbsp;</h1>
-													<p>{key}</p>
-												</div>
+												<f:alias map="{label: '{mask:label(elementKey: \'{storage.key}\', fieldKey: \'{key}\', table: \'tt_content\')}'}">
+													<div class="tx_mask_fieldheader_text" title="{label}">
+														<h1><f:format.crop maxCharacters="60" append="..."><mask:translateLabel key="{label}" /></f:format.crop>&nbsp;</h1>
+														<p>{key}</p>
+													</div>
+												</f:alias>
 											</div>
 
 											<div class="row tx_mask_fieldcontent">

--- a/Resources/Private/Backend/Templates/WizardPage/Edit.html
+++ b/Resources/Private/Backend/Templates/WizardPage/Edit.html
@@ -32,8 +32,14 @@
 											</div>
 											<div class="tx_mask_btn_text">
 												<span class="id_typetext"><f:translate key="tx_mask.field.{mask:formType(elementKey:'{storage.key}', fieldKey:'{key}', type: 'pages')}" /></span>
-												<span class="id_labeltext"><mask:label elementKey="{storage.key}" fieldKey="{key}" field="{field}" table="pages" /></span>
-												<span class="id_keytext">{field.key}</span>
+												<f:alias map="{label: '{mask:label(elementKey: \'{storage.key}\', fieldKey: \'{key}\', field: \'{field}\', table: \'pages\')}'}">
+													<span class="id_labeltext" title="{label}">
+														<f:format.crop maxCharacters="20" append="..."><mask:translateLabel key="{label}" /></f:format.crop>
+													</span>
+												</f:alias>
+												<span class="id_keytext" title="{field.key}">
+													<f:format.crop maxCharacters="20" append="...">{field.key}</f:format.crop>
+												</span>
 											</div>
 											<div class="tx_mask_btn_actions">
 												<span class="id_add" title="{f:translate(key:'tx_mask.field.titleAdd')}"><core:icon identifier="actions-edit-add" size="small" /></span>


### PR DESCRIPTION
Hallo Gernott,

ich habe gerade einen Patch für diese Extension erstellt. Generell übersetzt dieser die Labels im Backend-Modul, wenn diese ein Language-Label sind. Zudem wird das Label und der Key gekürzt, so das man auf meinen kleinen Laptop-Monitor noch arbeiten kann. :)

Beste Grüße,
Fabi 