### PR TITLE
[TASK] Use TypoScript to define field label

### DIFF
--- a/Classes/CodeGenerator/TyposcriptCodeGenerator.php
+++ b/Classes/CodeGenerator/TyposcriptCodeGenerator.php
@@ -69,13 +69,11 @@ class TyposcriptCodeGenerator extends AbstractCodeGenerator
                 $content.= $temp;
 
                 // Labels
-                $content .= "\n[userFunc = user_mask_contentType(CType|mask_" . $element["key"] . ")]\n";
                 if ($element["columns"]) {
                     foreach ($element["columns"] as $index => $column) {
-                        $content .= " TCEFORM.tt_content." . $column . ".label = " . $element["labels"][$index] . "\n";
+                        $content .= "\nTCEFORM.tt_content." . $column . ".types.mask_" . $element["key"] . ".label = " . $element["labels"][$index] . "\n";
                     }
                 }
-                $content .= "[end]\n\n";
             }
         }
         return $content;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -38,45 +38,6 @@ $pageTs = $typoScriptCodeGenerator->generatePageTyposcript($configuration);
 $setupTs = $typoScriptCodeGenerator->generateSetupTyposcript($configuration, $settings);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup($setupTs);
 
-// for conditions on tt_content
-if (!function_exists('user_mask_contentType')) {
-
-    function user_mask_contentType($param = "")
-    {
-        if (isset($_REQUEST["edit"]["tt_content"]) && is_array($_REQUEST["edit"]["tt_content"])) {
-            $field = explode("|", $param);
-            $request = $_REQUEST;
-            $first = array_shift($request["edit"]["tt_content"]);
-
-            if ($first == "new") { // if new element
-                if ($_REQUEST["defVals"]["tt_content"]["CType"] == $field[1]) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else { // if element exists
-                $uid = intval(key($_REQUEST["edit"]["tt_content"]));
-                $sql = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
-                    $field[0], "tt_content", "uid = " . $uid
-                );
-                $data = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($sql);
-                if ($data[$field[0]] == $field[1]) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        } else {
-            // if content element is loaded by ajax, then it's ok
-            if (is_array($_REQUEST["ajax"])) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    }
-}
-
 // for conditions on the backend-layouts
 if (!function_exists('user_mask_beLayout')) {
 


### PR DESCRIPTION
To set a label of a field depending in a CType no user function is needed. This can be done with pure TypoScript. The patch sets the needed TypoScript and removes the superfluous user function.