### PR TITLE
[BUGFIX] Fix overriding of partialRootPaths and layoutRootPaths

### DIFF
--- a/Classes/Controller/FrontendController.php
+++ b/Classes/Controller/FrontendController.php
@@ -5,7 +5,8 @@ namespace MASK\Mask\Controller;
 /**
  * FrontendController
  */
-
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  *
  *
@@ -56,14 +57,23 @@ class FrontendController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControl
         // load extension settings
         $this->extSettings = $this->settingsService->get();
 
+        // get framework configuration
+        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+        );
+
         // if there are paths for layouts and partials set, add them to view
         if (!empty($this->extSettings["layouts"])) {
-            $layoutRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($this->extSettings["layouts"]);
-            $this->view->setLayoutRootPaths(array($layoutRootPath));
+            $viewLayoutRootPaths = $this->getViewProperty($extbaseFrameworkConfiguration, 'layoutRootPaths');
+            $extSettingsLayoutRootPath = GeneralUtility::getFileAbsFileName($this->extSettings["layouts"]);
+
+            $this->view->setLayoutRootPaths(array_replace($viewLayoutRootPaths, [$extSettingsLayoutRootPath]));
         }
         if (!empty($this->extSettings["partials"])) {
-            $partialRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($this->extSettings["partials"]);
-            $this->view->setPartialRootPaths(array($partialRootPath));
+            $viewPartialRootPaths = $this->getViewProperty($extbaseFrameworkConfiguration, 'partialRootPaths');
+            $extSettingsPartialRootPath = GeneralUtility::getFileAbsFileName($this->extSettings["partials"]);
+
+            $this->view->setPartialRootPaths(array_replace($viewPartialRootPaths, [$extSettingsPartialRootPath]));
         }
         $this->view->setTemplatePathAndFilename($this->settings["file"]);
         $data = $this->configurationManager->getContentObject()->data;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mask/mask",
+	"name": "itplusx/mask",
 	"type": "typo3-cms-extension",
 	"description": "Create your own content elements and page templates. Easy to use, even without programming skills because of the comfortable drag&drop system. Stored in structured database tables. Style your frontend with Fluid tags. Ideal, if you want to switch from Templavoila.",
 	"homepage": "https://forge.typo3.org/projects/extension-mask",


### PR DESCRIPTION
Since `$this->view->setPartialRootPaths(array($partialRootPath));` and `$this->view->setLayoutRootPaths(array($layoutRootPath));` is overriding whatever is defined in `plugin.tx_mask.view` we have to combine the array with the value that is set in extension settings. Otherwise it's not possible to set other paths than the one in the extension settings once a path is set there.