### PR TITLE
[BUGFIX] Fixed missing $uid validation check

### DIFF
--- a/Classes/Domain/Model/Content.php
+++ b/Classes/Domain/Model/Content.php
@@ -39,7 +39,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Title for the New-Contentelement-Wizard.
      *
-     * @var \string
+     * @var string
      * @validate NotEmpty
      */
     protected $title;
@@ -47,21 +47,21 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Description for the New-Contentelement-Wizard.
      *
-     * @var \string
+     * @var string
      */
     protected $description;
 
     /**
      * Short Title for the Selectbox in Content-Edit-Mode.
      *
-     * @var \string
+     * @var string
      */
     protected $shorttitle;
 
     /**
      * Lowercase internal Key. Not Visible in TYPO3 Backend.
      *
-     * @var \string
+     * @var string
      * @validate NotEmpty
      */
     protected $fieldkey;
@@ -69,7 +69,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * contentType
      *
-     * @var \string
+     * @var string
      * @validate NotEmpty
      */
     protected $contentType;
@@ -79,7 +79,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         return $this->contentType;
     }
 
-    public function setContentType(\string $contentType)
+    public function setContentType($contentType)
     {
         $this->contentType = $contentType;
         return $this;
@@ -88,7 +88,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the title
      *
-     * @return \string $title
+     * @return string $title
      */
     public function getTitle()
     {
@@ -98,7 +98,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the title
      *
-     * @param \string $title
+     * @param string $title
      * @return void
      */
     public function setTitle($title)
@@ -109,7 +109,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the description
      *
-     * @return \string $description
+     * @return string $description
      */
     public function getDescription()
     {
@@ -119,7 +119,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the description
      *
-     * @param \string $description
+     * @param string $description
      * @return void
      */
     public function setDescription($description)
@@ -130,7 +130,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the shorttitle
      *
-     * @return \string $shorttitle
+     * @return string $shorttitle
      */
     public function getShorttitle()
     {
@@ -140,7 +140,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the shorttitle
      *
-     * @param \string $shorttitle
+     * @param string $shorttitle
      * @return void
      */
     public function setShorttitle($shorttitle)
@@ -151,7 +151,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the fieldkey
      *
-     * @return \string $fieldkey
+     * @return string $fieldkey
      */
     public function getFieldkey()
     {
@@ -161,7 +161,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the fieldkey
      *
-     * @param \string $fieldkey
+     * @param string $fieldkey
      * @return void
      */
     public function setFieldkey($fieldkey)

--- a/Classes/Domain/Model/Page.php
+++ b/Classes/Domain/Model/Page.php
@@ -39,7 +39,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Title of the Pagetemplate.
      *
-     * @var \string
+     * @var string
      * @validate NotEmpty
      */
     protected $title;
@@ -47,14 +47,14 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Backend layout
      *
-     * @var \integer
+     * @var integer
      */
     protected $belayout;
 
     /**
      * Lowercase internal Key. Not Visible in TYPO3 Backend.
      *
-     * @var \string
+     * @var string
      * @validate NotEmpty
      */
     protected $fieldkey;
@@ -62,7 +62,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Content for the HTML Head.
      *
-     * @var \string
+     * @var string
      */
     protected $header;
 
@@ -76,7 +76,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the title
      *
-     * @return \string $title
+     * @return string $title
      */
     public function getTitle()
     {
@@ -86,7 +86,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the title
      *
-     * @param \string $title
+     * @param string $title
      * @return void
      */
     public function setTitle($title)
@@ -97,7 +97,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the belayout
      *
-     * @return \integer $belayout
+     * @return integer $belayout
      */
     public function getBelayout()
     {
@@ -107,7 +107,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the belayout
      *
-     * @param \integer $belayout
+     * @param integer $belayout
      * @return void
      */
     public function setBelayout($belayout)
@@ -118,7 +118,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the fieldkey
      *
-     * @return \string $fieldkey
+     * @return string $fieldkey
      */
     public function getFieldkey()
     {
@@ -128,7 +128,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the fieldkey
      *
-     * @param \string $fieldkey
+     * @param string $fieldkey
      * @return void
      */
     public function setFieldkey($fieldkey)
@@ -139,7 +139,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the header
      *
-     * @return \string $header
+     * @return string $header
      */
     public function getHeader()
     {
@@ -149,7 +149,7 @@ class Page extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the header
      *
-     * @param \string $header
+     * @param string $header
      * @return void
      */
     public function setHeader($header)

--- a/Classes/Helper/InlineHelper.php
+++ b/Classes/Helper/InlineHelper.php
@@ -67,6 +67,10 @@ class InlineHelper
         } else {
             $uid = $data["uid"];
         }
+        
+        if(!is_int($uid)) {
+            return;
+        }
 
         $fieldHelper = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Helper\\FieldHelper');
         $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');

--- a/Classes/Helper/InlineHelper.php
+++ b/Classes/Helper/InlineHelper.php
@@ -68,7 +68,9 @@ class InlineHelper
             $uid = $data["uid"];
         }
         
-        if(!is_int($uid)) {
+        // using is_numeric in favor to is_int
+        // due to some rare cases where uids are provided as strings
+        if(!is_numeric($uid)) {
             return;
         }
 

--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -10,6 +10,8 @@
 
 ChangeLog
 =========
+Mask 2.1.1
+  PHP7 Compatibility fixed
 Mask 2.1.0
   New field type "Content", to nest content elements, possibility to set layouts- and partials rootpaths for backend and frontend, added TYPO3 8 and PHP7 Support, new controls (purge, deactive, element counter), enhanced support of language labels, better performance in frontend and backend, bugfixes
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -17,7 +17,7 @@ Mask
 		mask
 
 	:Version:
-		|2.1.0|
+		|2.1.1|
 
 	:Language:
 		en

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"license": ["GPL-2.0+"],
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"require": {
 		"typo3/cms-core": ">=7.6.0 <8.2.99"
 	},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,7 +1,7 @@
 <?php
 $EM_CONF[$_EXTKEY] = array(
     'title' => 'Mask',
-    'description' => 'Create your own content elements and page templates. Easy to use, even without programming skills because of the comfortable drag&drop system. Stored in structured database tables. Style your frontend with Fluid tags. Ideal, if you want to switch from Templavoila.',
+    'description' => 'Create your own content elements and page templates. Easy to use, even without programming skills because of the comfortable drag and drop system. Stored in structured database tables. Style your frontend with Fluid tags. Ideal, if you want to switch from Templavoila.',
     'category' => 'plugin',
     'author' => 'WEBprofil - Gernot Ploiner e.U.',
     'author_email' => 'office@webprofil.at',
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
     'modify_tables' => '',
     'clearCacheOnLoad' => 1,
     'lockType' => '',
-    'version' => '2.1.0',
+    'version' => '2.1.1',
     'constraints' => array(
         'depends' => array(
             'typo3' => '7.6.0-8.2.99',


### PR DESCRIPTION
You need to ensure that $uid is a valid integer. If it is not given (e.g. when rendering a FluidTemplate outside of a content element scope), the call in line 90 `$fileRepository->findByRelation($table, $fieldKey, $uid);` throws an exception.
