### PR TITLE
Reusable components (split mask.json)

### DIFF
--- a/Classes/Domain/Repository/StorageRepository.php
+++ b/Classes/Domain/Repository/StorageRepository.php
@@ -2,6 +2,8 @@
 
 namespace MASK\Mask\Domain\Repository;
 
+use MASK\Mask\Domain\Service\JsonService;
+
 /* * *************************************************************
  *  Copyright notice
  *
@@ -88,11 +90,7 @@ class StorageRepository
     public function load()
     {
         if (self::$json === null) {
-            if (!empty($this->extSettings["json"]) && file_exists(PATH_site . $this->extSettings["json"]) && is_file(PATH_site . $this->extSettings["json"])) {
-                self::$json = json_decode(file_get_contents(PATH_site . $this->extSettings["json"]), true);
-            } else {
-                self::$json = array();
-            }
+            self::$json = JsonService::getInstance()->getConfiguration(PATH_site . $this->extSettings["json"]);
         }
         return self::$json;
     }
@@ -104,13 +102,7 @@ class StorageRepository
      */
     public function write($json)
     {
-        // Return JSON formatted in PHP 5.4.0 and higher
-        if (version_compare(phpversion(), '5.4.0', '<')) {
-            $encodedJson = json_encode($json);
-        } else {
-            $encodedJson = json_encode($json, JSON_PRETTY_PRINT);
-        }
-        \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile(PATH_site . $this->extSettings["json"], $encodedJson);
+        JsonService::getInstance()->saveConfiguration(PATH_site . $this->extSettings["json"], $json);
         self::$json = $json;
     }
 

--- a/Classes/Domain/Repository/StorageRepository.php
+++ b/Classes/Domain/Repository/StorageRepository.php
@@ -68,12 +68,6 @@ class StorageRepository
     protected $extSettings;
 
     /**
-     * json configuration
-     * @var array
-     */
-    private static $json = null;
-
-    /**
      * is called before every action
      */
     public function __construct()
@@ -89,21 +83,15 @@ class StorageRepository
      */
     public function load()
     {
-        if (self::$json === null) {
-            self::$json = JsonService::getInstance()->getConfiguration(PATH_site . $this->extSettings["json"]);
-        }
-        return self::$json;
+        return JsonService::getInstance()->getConfiguration(PATH_site . $this->extSettings["json"]);
     }
 
     /**
      * Write Storage
-     *
-     * @return array
      */
     public function write($json)
     {
         JsonService::getInstance()->saveConfiguration(PATH_site . $this->extSettings["json"], $json);
-        self::$json = $json;
     }
 
     /**

--- a/Classes/Domain/Service/JsonService.php
+++ b/Classes/Domain/Service/JsonService.php
@@ -1,0 +1,166 @@
+<?php
+namespace MASK\Mask\Domain\Service;
+
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Class JsonService
+ * @package MASK\Mask\Domain\Service
+ */
+class JsonService implements SingletonInterface
+{
+    /**
+     * @var self|null
+     */
+    private static $_instance = null;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @return JsonService
+     */
+    public static function getInstance()
+    {
+        if (null === self::$_instance) {
+            self::$_instance = new self;
+
+            /* @var $message \TYPO3\CMS\Core\Messaging\FlashMessage */
+            self::$_instance->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        }
+        return self::$_instance;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    public function getConfiguration($path = '')
+    {
+        $data = [];
+        // check if path points to a file
+        if (substr($path, -strlen('.json')) == '.json') {
+            $data = GeneralUtility::getUrl($path) ?: array();
+        } else {
+            // path points to directory
+            $configurationFiles = GeneralUtility::getFilesInDir($path, 'json', true);
+            foreach ($configurationFiles as $filePath) {
+                $content = json_decode(GeneralUtility::getUrl($filePath), true) ?: array();
+                $errors = $this->searchForMergeError($data, $content);
+                if (!empty($errors)) {
+                    /* @var $flashMessageService \TYPO3\CMS\Core\Messaging\FlashMessageService */
+                    $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+                    $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
+
+                    /* @var $message \TYPO3\CMS\Core\Messaging\FlashMessage */
+                    $message = GeneralUtility::makeInstance(FlashMessage::class, sprintf(
+                        'The file "%s" couldn\'t be included due to following merge errors:%s',
+                        basename($filePath),
+                        implode('<br/>-', array_map(function ($value, $key) {
+                            return $key . ': ' . $value;
+                        }, $errors, array_keys($errors)))
+                    ));
+                    $message->setSeverity(FlashMessage::WARNING);
+                    $messageQueue->addMessage($message);
+                } else {
+                    ArrayUtility::mergeRecursiveWithOverrule($data, $content);
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param string $path
+     * @param array  $data
+     */
+    public function saveConfiguration($path, $data = [])
+    {
+        // check if path points to a file
+        if (substr($path, -strlen('.json')) == '.json') {
+            GeneralUtility::writeFile($path, $this->encodeJSON($data));
+        } else {
+            // path points to directory
+            if (!is_dir($path)) {
+                GeneralUtility::mkdir_deep($path);
+            }
+
+            $modules = $this->extractModules($data);
+            foreach ($modules as $key => $data) {
+                $filePath = rtrim($path, '/') . '/' . $key . '.json';
+                GeneralUtility::writeFile($filePath, $this->encodeJSON($data));
+            }
+        }
+    }
+
+    /**
+     * extracts all modules from configuration
+     *
+     * @param $data
+     *
+     * @return array
+     */
+    private function extractModules($data)
+    {
+        $modules = array();
+
+        if (isset($data['tt_content']['elements'])) {
+            foreach ($data['tt_content']['elements'] as $elementKey => $elementConfig) {
+                // TODO: extract modules from json
+                // key => should be filename
+            }
+        }
+
+        return $modules;
+    }
+
+    /**
+     * Recursively computes the intersection of arrays using keys for comparison.
+     *
+     * @param   array $array1 The array with master keys to check.
+     * @param   array $array2 An array to compare keys against.
+     *
+     * @return  array associative array containing all the entries of array1 which have keys that are present in array2.
+     **/
+    private function searchForMergeError(array $array1, array $array2)
+    {
+        $flatArray1 = ArrayUtility::flatten($array1);
+        $flatArray2 = ArrayUtility::flatten($array2);
+        $intersection = array_intersect_key($flatArray1, $flatArray2);
+
+        foreach ($intersection as $key => $value) {
+            if ($value == $flatArray2[$key]) {
+                unset($intersection[$key]);
+            } else {
+                $intersection[$key] .= ' => ' . $flatArray2[$key];
+            }
+        }
+
+        return $intersection;
+    }
+
+
+    /**
+     * Return JSON formatted in PHP 5.4.0 and higher
+     *
+     * @param $data
+     *
+     * @return string
+     */
+    private function encodeJSON($data)
+    {
+        if (version_compare(phpversion(), '5.4.0', '<')) {
+            return json_encode($data);
+        }
+        return json_encode($data, JSON_PRETTY_PRINT);
+    }
+}

--- a/Resources/Private/Backend/Templates/WizardContent/List.html
+++ b/Resources/Private/Backend/Templates/WizardContent/List.html
@@ -48,7 +48,7 @@
 								<mask:link data="{key}" />
 								</td>
 								<td class="text-center text-muted">
-								<f:comment><mask:elementCount key="{key}"/></f:comment>
+								<mask:elementCount key="{key}"/>
 								</td>
 								<td class="text-nowrap">
 

--- a/Resources/Private/Backend/Templates/WizardContent/List.html
+++ b/Resources/Private/Backend/Templates/WizardContent/List.html
@@ -48,7 +48,7 @@
 								<mask:link data="{key}" />
 								</td>
 								<td class="text-center text-muted">
-								<mask:elementCount key="{key}"/>
+								<f:comment><mask:elementCount key="{key}"/></f:comment>
 								</td>
 								<td class="text-nowrap">
 


### PR DESCRIPTION
**This merge requests aims to re-use components created with mask.** The new created JsonService is saving all components into seperate JSON files if the config parameter **json** from **ext_conf_template.txt** is not ending with **.json**. Otherwise all components will be saved in the specified file.

The newly created JsonService is reading all JSON files from the specfied directory and checking them for merge errors. Currently this is a simple check on flat arrays to find recursive keys with different values . The errors which were found are represented as flash messages in the current backend module. I think that these checks are currently enough due to the fact that mask is actually a developer/administrator extension and these group of persons should know how to deal with more complex merge conflicts.

The following requests can be solved or partially solved with this request:
- Reusable components https://forge.typo3.org/issues/72188
- Export for contentelements https://forge.typo3.org/issues/62227 (JsonService can also be used for this request)

If there are any questions or recommendations don't hesitate to ask or contact me ;)

With best regards
