### PR TITLE
[TASK] Remove version restriction for TYPO3 core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"license": ["GPL-2.0+"],
 	"version": "2.1.0",
 	"require": {
-		"typo3/cms-core": ">=7.6.0 <8.2.99"
+		"typo3/cms-core": ">=7.6.0 <8.99.99"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '2.1.0',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '7.6.0-8.2.99',
+            'typo3' => '7.6.0-8.99.99',
         ),
         'conflicts' => array(),
         'suggests' => array(


### PR DESCRIPTION
With this it' easier to test extension with TYPO3 8 dev-master
in an TYPO3 composer instance.

Resolves: https://forge.typo3.org/issues/77940
