### PR TITLE
[BUGFIX] Fix fluid templates for TYPO3 8

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Config/RteTransform.html
+++ b/Resources/Private/Backend/Partials/Forms/Config/RteTransform.html
@@ -4,6 +4,6 @@
 </label>
 <div class="t3js-formengine-field-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_rte_transform form-control" name="tx_mask_tools_maskmask[dummy][--index--][rte_transform]" type="text" placeholder="default is mode=ts_css" value="{f:if(condition: '{mask:rteTransform(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\')} == \'mode=ts_css\'', else: '{mask:rteTransform(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\')}')}" title="rte_transform" />
+		<input class="tx_mask_fieldcontent_rte_transform form-control" name="tx_mask_tools_maskmask[dummy][--index--][rte_transform]" type="text" placeholder="default is mode=ts_css" value="{f:if(condition: '{mask:rteTransform(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\')} == \'mode=ts_css\'', else: '{mask:rteTransform(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\')}')}" title="rte_transform" />
 	</div>
 </div>

--- a/Resources/Private/Backend/Partials/Forms/Eval/Alpha.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Alpha.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alpha]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'alpha\')}', then: 'checked="checked"', else: '')} value="alpha" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alpha]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'alpha\')}', then: 'checked="checked"', else: '')} value="alpha" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/AlphaNum.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/AlphaNum.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alphanum]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'alphanum\')}', then: 'checked="checked"', else: '')} value="alphanum" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alphanum]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'alphanum\')}', then: 'checked="checked"', else: '')} value="alphanum" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/AlphaNumX.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/AlphaNumX.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alphanum_x]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'alphanum_x\')}', then: 'checked="checked"', else: '')} value="alphanum_x" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][alphanum_x]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'alphanum_x\')}', then: 'checked="checked"', else: '')} value="alphanum_x" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Domainname.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Domainname.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][domainname]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'domainname\')}', then: 'checked="checked"', else: '')} value="domainname" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][domainname]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'domainname\')}', then: 'checked="checked"', else: '')} value="domainname" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Email.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Email.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][email]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'email\')}', then: 'checked="checked"', else: '')} value="email" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][email]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'email\')}', then: 'checked="checked"', else: '')} value="email" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Lower.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Lower.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][lower]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'lower\')}', then: 'checked="checked"', else: '')} value="lower" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][lower]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'lower\')}', then: 'checked="checked"', else: '')} value="lower" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Md5.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Md5.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" >
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][md5]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'md5\')}', then: 'checked="checked"', else: '')} value="md5" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][md5]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'md5\')}', then: 'checked="checked"', else: '')} value="md5" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/NoSpace.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/NoSpace.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" >
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][nospace]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'nospace\')}', then: 'checked="checked"', else: '')} value="nospace" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][nospace]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'nospace\')}', then: 'checked="checked"', else: '')} value="nospace" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Null.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Null.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][null]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'null\')}', then: 'checked="checked"', else: '')} value="null" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][null]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'null\')}', then: 'checked="checked"', else: '')} value="null" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Num.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Num.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][num]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'num\')}', then: 'checked="checked"', else: '')} value="num" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][num]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'num\')}', then: 'checked="checked"', else: '')} value="num" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Password.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Password.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][password]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'password\')}', then: 'checked="checked"', else: '')} value="password" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][password]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'password\')}', then: 'checked="checked"', else: '')} value="password" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Required.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Required.html
@@ -1,8 +1,8 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][required]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'required\')}', then: 'checked="checked"', else: '')} value="required" title="Required" />
-	</div>
+        <input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][required]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'required\')}', then: 'checked="checked"', else: '')} value="required" title="Required" />
+    </div>
 </div>
 <label class="t3js-formengine-label check-item">
 	<f:translate key="tx_mask.field.required" />

--- a/Resources/Private/Backend/Partials/Forms/Eval/Time.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Time.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][time]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'time\')}', then: 'checked="checked"', else: '')} value="time" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][time]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'time\')}', then: 'checked="checked"', else: '')} value="time" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/TimeSec.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/TimeSec.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][timesec]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'timesec\')}', then: 'checked="checked"', else: '')} value="timesec" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][timesec]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'timesec\')}', then: 'checked="checked"', else: '')} value="timesec" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Trim.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Trim.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][trim]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'trim\')}', then: 'checked="checked"', else: '')} value="trim" title="{f:translate(key:'tx_mask.content.trim')}" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][trim]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'trim\')}', then: 'checked="checked"', else: '')} value="trim" title="{f:translate(key:'tx_mask.content.trim')}" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Unique.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Unique.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][unique]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'unique\')}', then: 'checked="checked"', else: '')} value="unique" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][unique]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'unique\')}', then: 'checked="checked"', else: '')} value="unique" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/UniqueInPid.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/UniqueInPid.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][uniqueInPid]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'uniqueInPid\')}', then: 'checked="checked"', else: '')} value="uniqueInPid" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][uniqueInPid]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'uniqueInPid\')}', then: 'checked="checked"', else: '')} value="uniqueInPid" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Upper.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Upper.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][upper]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'upper\')}', then: 'checked="checked"', else: '')} value="upper" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][upper]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'upper\')}', then: 'checked="checked"', else: '')} value="upper" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Eval/Year.html
+++ b/Resources/Private/Backend/Partials/Forms/Eval/Year.html
@@ -1,7 +1,7 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <div class="t3js-formengine-field-item check-item">
 	<div class="form-control-wrap" style="">
-		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][year]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', evalValue:\'year\')}', then: 'checked="checked"', else: '')} value="year" title="Required" />
+		<input class="tx_mask_fieldcontent_eval" name="tx_mask_tools_maskmask[dummy][--index--][year]" type="checkbox" {f:if(condition: '{mask:eval(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', evalValue:\'year\')}', then: 'checked="checked"', else: '')} value="year" title="Required" />
 	</div>
 </div>
 <label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Link/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Link/Tabs.html
@@ -47,7 +47,7 @@
 			</label>
 			<div class="t3js-formengine-field-item">
 				<div class="form-control-wrap" style="">
-					<input class="tx_mask_fieldcontent_jsopenparams form-control" name="tx_mask_tools_maskmask[dummy][--index--][height]" required="required" data-property="height" type="number" value="{mask:jsOpenParams(fieldKey:'{key}', field:'{field}', elementKey:'{elementKey}', property:'height')}" title="height" />
+					<input class="tx_mask_fieldcontent_jsopenparams form-control" name="tx_mask_tools_maskmask[dummy][--index--][height]" required="required" data-property="height" type="number" value="{mask:jsOpenParams(fieldKey:'{key}', field: field, elementKey:'{elementKey}', property:'height')}" title="height" />
 				</div>
 			</div>
 		</div>
@@ -57,7 +57,7 @@
 			</label>
 			<div class="t3js-formengine-field-item">
 				<div class="form-control-wrap" style="">
-					<input class="tx_mask_fieldcontent_jsopenparams form-control" name="tx_mask_tools_maskmask[dummy][--index--][width]" required="required" data-property="width" type="number" value="{mask:jsOpenParams(fieldKey:'{key}', field:'{field}', elementKey:'{elementKey}', property:'width')}" title="width" />
+					<input class="tx_mask_fieldcontent_jsopenparams form-control" name="tx_mask_tools_maskmask[dummy][--index--][width]" required="required" data-property="width" type="number" value="{mask:jsOpenParams(fieldKey:'{key}', field: field, elementKey:'{elementKey}', property:'width')}" title="width" />
 				</div>
 			</div>
 		</div>
@@ -66,7 +66,7 @@
 		<div class="form-group col-sm-6">
 			<div class="t3js-formengine-field-item check-item">
 				<div class="form-control-wrap" style="">
-					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][status]" data-property="status" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', property:\'status\')}', then: 'checked="checked"', else: '')} value="1" title="status" />
+					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][status]" data-property="status" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', property:\'status\')}', then: 'checked="checked"', else: '')} value="1" title="status" />
 				</div>
 			</div>
 			<label class="t3js-formengine-label check-item">
@@ -76,7 +76,7 @@
 		<div class="form-group col-sm-6">
 			<div class="t3js-formengine-field-item check-item">
 				<div class="form-control-wrap" style="">
-					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][menubar]" data-property="menubar" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', property:\'menubar\')}', then: 'checked="checked"', else: '')} value="1" title="menubar" />
+					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][menubar]" data-property="menubar" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', property:\'menubar\')}', then: 'checked="checked"', else: '')} value="1" title="menubar" />
 				</div>
 			</div>
 			<label class="t3js-formengine-label check-item">
@@ -88,7 +88,7 @@
 		<div class="form-group col-sm-6">
 			<div class="t3js-formengine-field-item check-item">
 				<div class="form-control-wrap" style="">
-					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][scrollbars]" data-property="scrollbars" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field:\'{field}\', elementKey:\'{elementKey}\', property:\'scrollbars\')}', then: 'checked="checked"', else: '')} value="1" title="scrollbars" />
+					<input class="tx_mask_fieldcontent_jsopenparams" name="tx_mask_tools_maskmask[dummy][--index--][scrollbars]" data-property="scrollbars" type="checkbox" {f:if(condition: '{mask:jsOpenParams(fieldKey:\'{key}\', field: field, elementKey:\'{elementKey}\', property:\'scrollbars\')}', then: 'checked="checked"', else: '')} value="1" title="scrollbars" />
 				</div>
 			</div>
 			<label class="t3js-formengine-label check-item">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Tabs.html
@@ -7,10 +7,10 @@
 	</div>
 	<div class="row">
 		<div class="form-group col-sm-6">
-			<f:render partial="Forms/Eval/Required" arguments="{key:key, elementKey:storage.key, field:field}" />
+			<f:render partial="Forms/Eval/Required" arguments="{key:key, elementKey:storage.key, field: field}" />
 		</div>
 		<div class="form-group col-sm-6">
-			<f:render partial="Forms/Eval/Trim" arguments="{key:key, elementKey:storage.key, field:field}" />
+			<f:render partial="Forms/Eval/Trim" arguments="{key:key, elementKey:storage.key, field: field}" />
 		</div>
 	</div>
 	<div class="row">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Text/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Text/Tabs.html
@@ -7,10 +7,10 @@
 	</div>
 	<div class="row">
 		<div class="form-group col-sm-6">
-			<f:render partial="Forms/Eval/Required" arguments="{key:key, elementKey:storage.key, field:field}" />
+			<f:render partial="Forms/Eval/Required" arguments="{key:key, elementKey:storage.key, field: field}" />
 		</div>
 		<div class="form-group col-sm-6">
-			<f:render partial="Forms/Eval/Trim" arguments="{key:key, elementKey:storage.key, field:field}" />
+			<f:render partial="Forms/Eval/Trim" arguments="{key:key, elementKey:storage.key, field: field}" />
 		</div>
 	</div>
 	<div class="row">

--- a/Resources/Private/Backend/Partials/Forms/General/RenderFieldContent.html
+++ b/Resources/Private/Backend/Partials/Forms/General/RenderFieldContent.html
@@ -1,10 +1,10 @@
 {namespace mask=MASK\Mask\ViewHelpers}
 <f:if condition="{field.inlineParent}">
 	<f:then>
-		<f:render partial="Forms/General/Form" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: field.inlineParent)}', storage: storage, field:field, key:key, editMode: 1, type: type}" />
+		<f:render partial="Forms/General/Form" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: field.inlineParent)}', storage: storage, field: field, key:key, editMode: 1, type: type}" />
 	</f:then>
 	<f:else>
-		<f:render partial="Forms/General/Form" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: type)}', storage: storage, field:field, key:key, editMode: 1, type: type}" />
+		<f:render partial="Forms/General/Form" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: type)}', storage: storage, field: field, key:key, editMode: 1, type: type}" />
 	</f:else>
 </f:if>
 <f:if condition="{field.inlineFields}">

--- a/Resources/Private/Backend/Templates/WizardContent/Edit.html
+++ b/Resources/Private/Backend/Templates/WizardContent/Edit.html
@@ -67,7 +67,7 @@
 								<f:if condition="{mask:substr(string: key, search: 'tx_mask', from: 0, length: 7)}">
 									<f:then>
 										<!--Mask-Field-->
-										<f:render partial="Forms/General/RenderFieldContent" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key)}', storage: storage, field:field, key:key, editMode: 1, type: 'tt_content'}" />
+										<f:render partial="Forms/General/RenderFieldContent" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key)}', storage: storage, field: field, key:key, editMode: 1, type: 'tt_content'}" />
 									</f:then>
 									<f:else>
 										<!--TYPO3-Standard-Field-->

--- a/Resources/Private/Backend/Templates/WizardPage/Edit.html
+++ b/Resources/Private/Backend/Templates/WizardPage/Edit.html
@@ -65,7 +65,7 @@
 							<!--Edit-Mode-Features -->
 							<f:for each="{storage.tca}" as="field" key="key">
 								<f:if condition="{mask:substr(string: key, search: 'tx_mask', from: 0, length: 7)}">
-									<f:render partial="Forms/General/RenderFieldContent" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: \'pages\')}', storage: storage, field:field, key:key, editMode: 1, type: 'pages'}" />
+									<f:render partial="Forms/General/RenderFieldContent" arguments="{form: '{mask:formType(elementKey:storage.key, fieldKey:key, type: \'pages\')}', storage: storage, field: field, key:key, editMode: 1, type: 'pages'}" />
 								</f:if>
 							</f:for>
 						</div>


### PR DESCRIPTION
As the field variable within fluid templates is an array, it cannot be
used as string. This currently results in a fatal error, because
htmlspecialchars on an array cannot be applied.
