### PR TITLE
Fix sys language selector

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -354,7 +354,7 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                         'foreign_table_where' => 'ORDER BY sys_language.title',
                         'default' => '0',
                         'items' => array(
-                            array('LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1),
+                            array('LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1, 'flags-multiple')
                             array('LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0)
                         ),
                     ),

--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -352,6 +352,7 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                         'renderType' => 'selectSingle',
                         'foreign_table' => 'sys_language',
                         'foreign_table_where' => 'ORDER BY sys_language.title',
+                        'default' => '0',
                         'items' => array(
                             array('LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1),
                             array('LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0)


### PR DESCRIPTION
By default, the language selector uses [All]. This works fine as long as EXT:mask is used to display the content. However, when exporting content with EXT:mask_export, the content is hidden unless config.sys_language_overlay is set.

No matter what, I think it's wrong that the default language is set to [All].
