### PR TITLE
[BUGFIX] Remove leading backslash of scalar type

### DIFF
--- a/Classes/Domain/Model/Content.php
+++ b/Classes/Domain/Model/Content.php
@@ -79,7 +79,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         return $this->contentType;
     }
 
-    public function setContentType(\string $contentType)
+    public function setContentType(string $contentType)
     {
         $this->contentType = $contentType;
         return $this;


### PR DESCRIPTION
The leading backslash is not accepted since PHP 7.0.1

See: http://php.net/ChangeLog-7.php