### PR TITLE
[FEATURE] Support multiple / context based configurations

### DIFF
--- a/Classes/CodeGenerator/TyposcriptCodeGenerator.php
+++ b/Classes/CodeGenerator/TyposcriptCodeGenerator.php
@@ -165,7 +165,7 @@ module.tx_mask {
             foreach ($configuration["tt_content"]["elements"] as $element) {
                 if (!$element["hidden"]) {
                     $temp = str_replace("###KEY###", $element["key"], $template);
-                    $temp = str_replace("###PATH###", $settings['content'] . $element["key"] . '.html', $temp);
+                    $temp = str_replace("###PATH###", $element["key"] . '.html', $temp);
                     $setupContent.= $temp;
                 }
             }

--- a/Classes/Controller/FrontendController.php
+++ b/Classes/Controller/FrontendController.php
@@ -56,27 +56,21 @@ class FrontendController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControl
     public function contentelementAction()
     {
         // load extension settings
-        $this->extSettings = $this->settingsService->get();
-
-        // get framework configuration
-        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
-        );
+        $this->extSettings = $this->settingsService->getFrontendSettings();
 
         // if there are paths for layouts and partials set, add them to view
         if (!empty($this->extSettings["layouts"])) {
-            $viewLayoutRootPaths = $this->getViewProperty($extbaseFrameworkConfiguration, 'layoutRootPaths');
-            $extSettingsLayoutRootPath = GeneralUtility::getFileAbsFileName($this->extSettings["layouts"]);
-
-            $this->view->setLayoutRootPaths(array_replace($viewLayoutRootPaths, [$extSettingsLayoutRootPath]));
+            $this->view->setLayoutRootPaths($this->extSettings["layouts"]);
         }
         if (!empty($this->extSettings["partials"])) {
-            $viewPartialRootPaths = $this->getViewProperty($extbaseFrameworkConfiguration, 'partialRootPaths');
-            $extSettingsPartialRootPath = GeneralUtility::getFileAbsFileName($this->extSettings["partials"]);
-
-            $this->view->setPartialRootPaths(array_replace($viewPartialRootPaths, [$extSettingsPartialRootPath]));
+            $this->view->setPartialRootPaths($this->extSettings["partials"]);
         }
-        $this->view->setTemplatePathAndFilename($this->settings["file"]);
+        foreach ($this->extSettings['frontend'] as $templatePath) {
+            $fileName = $templatePath . $this->settings["file"];
+            if (is_file($fileName)) {
+                $this->view->setTemplatePathAndFilename($fileName);
+            }
+        }
         $data = $this->configurationManager->getContentObject()->data;
         $this->inlineHelper->addFilesToData($data, "tt_content");
         $this->inlineHelper->addIrreToData($data);

--- a/Classes/Controller/WizardContentController.php
+++ b/Classes/Controller/WizardContentController.php
@@ -199,11 +199,15 @@ class WizardContentController extends \MASK\Mask\Controller\WizardController
      */
     protected function deleteHtml($key)
     {
-        if (file_exists(PATH_site . $this->extSettings["content"] . $key . ".html")) {
-            unlink(PATH_site . $this->extSettings["content"] . $key . ".html");
+        foreach ($this->extSettings["content"] as $templatePath) {
+            if (file_exists(PATH_site . $templatePath . $key . ".html")) {
+                unlink(PATH_site . $templatePath . $key . ".html");
+            }
         }
-        if (file_exists(PATH_site . $this->extSettings["backend"] . $key . ".html")) {
-            unlink(PATH_site . $this->extSettings["backend"] . $key . ".html");
+        foreach ($this->extSettings["backend"] as $templatePath) {
+            if (file_exists(PATH_site . $templatePath . $key . ".html")) {
+                unlink(PATH_site . $templatePath . $key . ".html");
+            }
         }
     }
 }

--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -101,7 +101,7 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
      */
     public function initializeAction()
     {
-        $this->extSettings = $this->settingsService->get();
+        $this->extSettings = $this->settingsService->getBackendSettings();
     }
 
     /**
@@ -157,12 +157,13 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
      */
     protected function saveHtml($key, $html)
     {
-        if (file_exists(PATH_site . $this->extSettings["content"] . $key . ".html")) {
-            return false;
-        } else {
-            \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile(PATH_site . $this->extSettings["content"] . $key . ".html", $html);
-            return true;
+        foreach ($this->extSettings["content"] as $templatePath) {
+            if (!file_exists(PATH_site . $templatePath . $key . ".html")) {
+                \TYPO3\CMS\Core\Utility\GeneralUtility::writeFile(PATH_site . $templatePath . $key
+                    . ".html", $html);
+            }
         }
+        return true;
     }
 
     /**
@@ -176,7 +177,7 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     public function checkFieldKey($params = array(), \TYPO3\CMS\Core\Http\AjaxRequestHandler &$ajaxObj = NULL)
     {
         $this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-        $this->storageRepository = $this->objectManager->get("MASK\Mask\Domain\Repository\StorageRepository");
+        $this->storageRepository = $this->objectManager->get('MASK\\Mask\\Domain\\Repository\\StorageRepository');
         // Get parameters, is there a better way? $params is not used yet
         $fieldKey = $_GET["key"];
         if ($_GET["table"]) {
@@ -205,7 +206,7 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     public function checkElementKey($params = array(), \TYPO3\CMS\Core\Http\AjaxRequestHandler &$ajaxObj = NULL)
     {
         $this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-        $this->storageRepository = $this->objectManager->get("MASK\Mask\Domain\Repository\StorageRepository");
+        $this->storageRepository = $this->objectManager->get('MASK\\Mask\\Domain\\Repository\\StorageRepository');
         // Get parameters, is there a better way? $params is not used yet
         $elementKey = $_GET["key"];
         // check if elementKey is available
@@ -249,11 +250,20 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
      */
     protected function checkFolders()
     {
-        if (!file_exists(PATH_site . $this->extSettings["content"])) {
-            $message[] = $this->extSettings["content"] . ": " . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.all.error.missingfolder', 'mask');
+        $message = array();
+        foreach ($this->extSettings["content"] as $templatePath) {
+            if (!file_exists(PATH_site . $templatePath)) {
+                $message[] = $templatePath . ": "
+                    . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.all.error.missingfolder',
+                        'mask');
+            }
         }
-        if (!file_exists(PATH_site . $this->extSettings["preview"])) {
-            $message[] = $this->extSettings["preview"] . ": " . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.all.error.missingfolder', 'mask');
+        foreach ($this->extSettings["preview"] as $templatePath) {
+            if (!file_exists(PATH_site . $templatePath)) {
+                $message[] = $templatePath . ": "
+                    . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.all.error.missingfolder',
+                        'mask');
+            }
         }
         return $message;
     }
@@ -266,11 +276,15 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     protected function createMissingFolders()
     {
         $success = TRUE;
-        if (!file_exists(PATH_site . $this->extSettings["content"])) {
-            $success = $success && mkdir(PATH_site . $this->extSettings["content"], 0755, true);
+        foreach ($this->extSettings["content"] as $templatePath) {
+            if (!file_exists(PATH_site . $templatePath)) {
+                $success = $success && mkdir(PATH_site . $templatePath, 0755, true);
+            }
         }
-        if (!file_exists(PATH_site . $this->extSettings["preview"])) {
-            $success = $success && mkdir(PATH_site . $this->extSettings["preview"], 0755, true);
+        foreach ($this->extSettings["preview"] as $templatePath) {
+            if (!file_exists(PATH_site . $templatePath)) {
+                $success = $success && mkdir(PATH_site . $templatePath, 0755, true);
+            }
         }
         return $success;
     }

--- a/Classes/Domain/Service/SettingsService.php
+++ b/Classes/Domain/Service/SettingsService.php
@@ -35,19 +35,9 @@ class SettingsService
 {
 
     /**
-     * Contains the settings of the current extension
-     *
-     * @var array
-     * @api
+     * @var \TYPO3\CMS\Extbase\Object\ObjectManager
      */
-    protected $settings = array();
-
-    /**
-     * Contains the settings of the typoscript
-     *
-     * @var array
-     */
-    protected $typoscriptSettings;
+    protected $objectManager = null;
 
     /**
      * Contains the settings of the $_EXTCONF
@@ -76,6 +66,72 @@ class SettingsService
         if (empty($extSettings)) {
             $extSettings = $_EXTCONF;
         }
+        return $extSettings;
+    }
+
+    /**
+     * Returns an array with backend specific paths, based on typoscript settings
+     * @return array
+     */
+    public function getBackendSettings() {
+        $extSettings = $this->getExtensionTyposcriptSettings();
+
+        $settings = array();
+        $settings['backend'] = $this->setTemplate($extSettings['settings']['beview'], 'template');
+        $settings['layouts_backend'] = $this->setTemplate($extSettings['settings']['beview'], 'layout');
+        $settings['partials_backend'] = $this->setTemplate($extSettings['settings']['beview'], 'partial');
+        $settings['preview'] = $this->setTemplate($extSettings['settings']['beview'], 'preview');
+        $settings['content'] = $this->setTemplate($extSettings['settings']['beview'], 'content');
+
+        return $settings;
+    }
+
+    /**
+     * Returns an array with backend specific paths, based on typoscript settings
+     * @return array
+     */
+    public function getFrontendSettings() {
+        $extSettings = $this->getExtensionTyposcriptSettings();
+
+        $settings = array();
+        $settings['frontend'] = $this->setTemplate($extSettings['settings']['feview'], 'template');
+        $settings['layouts'] = $this->setTemplate($extSettings['settings']['feview'], 'layout');
+        $settings['partials'] = $this->setTemplate($extSettings['settings']['feview'], 'partial');
+
+        return $settings;
+    }
+
+    /**
+     * Set template for view (backend and frontend)
+     *
+     * @param $templatePaths
+     * @param $templateKey
+     *
+     * @return string
+     */
+    public function setTemplate($templatePaths, $templateKey) {
+        $possibleTemplatePaths = $templatePaths[$templateKey . 'RootPaths'];
+        /*
+        $templatePathAndFilename = null;
+        foreach ($possibleTemplatePaths as $possibleTemplatePath) {
+            if (is_dir(\TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($possibleTemplatePath))) {
+                $templatePathAndFilename = $possibleTemplatePath;
+            }
+        }
+        */
+
+        return $possibleTemplatePaths;
+    }
+
+    /**
+     * Returns mask typoscript settings
+     *
+     * @return array
+     */
+    protected function getExtensionTyposcriptSettings() {
+        $this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
+        $configurationManager = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface');
+        $extSettings = $configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'mask');
         return $extSettings;
     }
 }

--- a/Classes/Imaging/IconProvider/ContentElementIconProvider.php
+++ b/Classes/Imaging/IconProvider/ContentElementIconProvider.php
@@ -77,9 +77,9 @@ class ContentElementIconProvider implements IconProviderInterface
             throw new \InvalidArgumentException('The option "contentElementKey" is required and must not be empty', 1440754978);
         }
         $this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-        $this->storageRepository = $this->objectManager->get("MASK\Mask\Domain\Repository\StorageRepository");
+        $this->storageRepository = $this->objectManager->get('MASK\\Mask\\Domain\\Repository\\StorageRepository');
         $this->settingsService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Service\\SettingsService');
-        $this->extSettings = $this->settingsService->get();
+        $this->extSettings = $this->settingsService->getBackendSettings();
         $this->contentElement = $this->storageRepository->loadElement("tt_content", $options["contentElementKey"]);
         $icon->setMarkup($this->generateMarkup($icon, $options));
     }

--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -40,14 +40,20 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
      */
     public function render($data)
     {
-        $this->extSettings = $this->settingsService->get();
-        $url = $this->extSettings['content'] . $data . '.html';
-        if (!file_exists(PATH_site . $url) || !is_file(PATH_site . $url)) {
-            $content = '<div class="typo3-message message-error"><strong>' .
-                \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.content.error', 'mask') .
-                '</strong> ' . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.content.htmlmissing', 'mask') .
-                ': <span style="text-decoration:underline;">' . $url .
-                '</span></div>';
+        $content = '';
+        $this->extSettings = $this->settingsService->getBackendSettings();
+        foreach ($this->extSettings['content'] as $templatePath) {
+            $url = $templatePath . $data . '.html';
+            if (!file_exists(PATH_site . $url) || !is_file(PATH_site . $url)) {
+                $content = '<div class="typo3-message message-error"><strong>' .
+                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.content.error', 'mask') .
+                    '</strong> '
+                    . \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_mask.content.htmlmissing', 'mask') .
+                    ': <span style="text-decoration:underline;">' . $url .
+                    '</span></div>';
+            } else {
+                return '';
+            }
         }
         return $content;
     }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -141,3 +141,26 @@ lib.parseFunc_RTE {
 		htmlSpecialChars = 2
 	}
 }
+
+plugin.tx_mask {
+	settings {
+		feview {
+			templateRootPaths.0 = templates/content/
+			partialRootPaths.0 = templates/content/Partials/
+			layoutRootPaths.0 = templates/content/Layout/
+		}
+	}
+}
+
+module.tx_mask {
+	settings {
+		beview {
+			templateRootPaths.0 = templates/backend/
+			partialRootPaths.0 = templates/backend/Partials/
+			layoutRootPaths.0 = templates/backend/Layout/
+			previewRootPaths.0 = templates/preview/
+			contentRootPaths.0 = templates/content/
+			jsonRootPaths.0 = typo3conf/mask.json
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -1,47 +1,44 @@
-<img src="https://forge.typo3.org/headerimages/3021.jpg" width="100%" />
+###Fork for Gernott/mask
+[Github Repo](https://github.com/Gernott/mask)
 
-mask
-======================
+###Request
+Find a good solution for [Forge Ticket](https://forge.typo3.org/issues/75312) Its a big topic and i need feedback
 
-Create your own content elements and page templates. Easy to use, even without programming skills because of the comfortable drag&drop system. Stored in structured database tables.
+###Changes
+- All $extSettings paths filled by settings service. This service was extend by two new getters:
+  - frontendService
+  - backendService
+- JSON path is further available in ExtConf 
+- Default mask path is set outside from fileadmin. fileadmin should filled by generated content?
+- HTML Files for new elements would be saved in every path entry
 
-##What does it do?
+###Individual paths
+You can control this paths with typoscript:
 
-Mask is a TYPO3-extension for creating contentelements and extend pagetemplates. It is possible to add new fields to any element. Fields can have serveral types, for example: text, file, relations, richtext,...
+####Frontend
+<pre>
+plugin.tx_mask {
+  settings {
+    feview {
+      templateRootPaths.1 = templates2/content/
+      partialRootPaths.1 = templates2/content/Partials/
+      layoutRootPaths.1 = templates2/content/Layout/
+    }
+  }
+}
+</pre>
 
-##Advantages of Mask
-
-* Mask stores the content in columns in databasetables - not in XML (Flexform)
-* Mask reuses existing database-fields to conserve the database
-* Mask works only with existing features of the TYPO3-core: backend_layouts, fluid, typoscript, 
-* Mask allows repeating content with IRRE-technology
-* Mask supports multilanguage projects and resolves some language-bugs of TYPO3
-* Mask supports workspaces and versioning
-* Mask is written in Extbase, the modern way to create extensions
-
-Installation
-------------
-
-To install the extension, perform the following steps:
-
-1. Import and install the Extension in the TYPO3-Backend in Module **Extensionmanager**.
-
-2. Include static template **Mask** in Module **Template** in your main TypoScript-Template.
-
-3. After installation, check the extension-settings:
-
-  * File with project-specific mask configuration. [basic.json]
-  Mask stores the information, which is needed to generate contentelements and extend pagetemplates, into one file: mask.json. With this setting you can change the path to this file.
-  Default is: typo3conf/mask.json
-
-  * Folder for Content Fluid Templates (with ending slash). [basic.content]
-  Mask generates a html-file with fluid-tags for each new contentelement. Here you can set the folder of this file.
-  Default is: fileadmin/templates/content/
-
-  * Folder for preview-images (with ending slash). [basic.preview]
-  Mask takes a copy of the Mask-logo as preview-image for each new contentelement. Yes, afterwards you should change this image to your prefered preview-image or icon. Here you can set the path to the preview-images.
-  Default is: fileadmin/templates/preview/
-
-  * Folder for backend fluid templates (with ending slash). [basic.backend]
- With mask you can style the backend preview of your content elements. Here you can set the path to your backend fluid templates.
-  Default is: fileadmin/templates/backend/
+####Backend
+<pre>
+module.tx_mask {
+  settings {
+    beview {
+      templateRootPaths.1 = templates2/backend/
+      partialRootPaths.1 = templates2/backend/Partials/
+      layoutRootPaths.1 = templates2/backend/Layout/
+      previewRootPaths.1 = templates2/preview/
+      contentRootPaths.1 = templates2/content/      
+    }
+  }
+}
+</pre>

--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
-###Fork for Gernott/mask
-[Github Repo](https://github.com/Gernott/mask)
+<img src="https://forge.typo3.org/headerimages/3021.jpg" width="100%" />
 
-###Request
-Find a good solution for [Forge Ticket](https://forge.typo3.org/issues/75312) Its a big topic and i need feedback
+mask
+======================
 
-###Changes
-- All $extSettings paths filled by settings service. This service was extend by two new getters:
-  - frontendService
-  - backendService
-- JSON path is further available in ExtConf 
-- Default mask path is set outside from fileadmin. fileadmin should filled by generated content?
-- HTML Files for new elements would be saved in every path entry
+Create your own content elements and page templates. Easy to use, even without programming skills because of the comfortable drag&drop system. Stored in structured database tables.
 
-###Individual paths
-You can control this paths with typoscript:
+##What does it do?
 
-####Frontend
-<pre>
-plugin.tx_mask {
-  settings {
-    feview {
-      templateRootPaths.1 = templates2/content/
-      partialRootPaths.1 = templates2/content/Partials/
-      layoutRootPaths.1 = templates2/content/Layout/
-    }
-  }
-}
-</pre>
+Mask is a TYPO3-extension for creating contentelements and extend pagetemplates. It is possible to add new fields to any element. Fields can have serveral types, for example: text, file, relations, richtext,...
 
-####Backend
-<pre>
-module.tx_mask {
-  settings {
-    beview {
-      templateRootPaths.1 = templates2/backend/
-      partialRootPaths.1 = templates2/backend/Partials/
-      layoutRootPaths.1 = templates2/backend/Layout/
-      previewRootPaths.1 = templates2/preview/
-      contentRootPaths.1 = templates2/content/      
-    }
-  }
-}
-</pre>
+##Advantages of Mask
+
+* Mask stores the content in columns in databasetables - not in XML (Flexform)
+* Mask reuses existing database-fields to conserve the database
+* Mask works only with existing features of the TYPO3-core: backend_layouts, fluid, typoscript, 
+* Mask allows repeating content with IRRE-technology
+* Mask supports multilanguage projects and resolves some language-bugs of TYPO3
+* Mask supports workspaces and versioning
+* Mask is written in Extbase, the modern way to create extensions
+
+Installation
+------------
+
+To install the extension, perform the following steps:
+
+1. Import and install the Extension in the TYPO3-Backend in Module **Extensionmanager**.
+
+2. Include static template **Mask** in Module **Template** in your main TypoScript-Template.
+
+3. After installation, check the extension-settings:
+
+  * File with project-specific mask configuration. [basic.json]
+  Mask stores the information, which is needed to generate contentelements and extend pagetemplates, into one file: mask.json. With this setting you can change the path to this file.
+  Default is: typo3conf/mask.json
+
+  * Folder for Content Fluid Templates (with ending slash). [basic.content]
+  Mask generates a html-file with fluid-tags for each new contentelement. Here you can set the folder of this file.
+  Default is: fileadmin/templates/content/
+
+  * Folder for preview-images (with ending slash). [basic.preview]
+  Mask takes a copy of the Mask-logo as preview-image for each new contentelement. Yes, afterwards you should change this image to your prefered preview-image or icon. Here you can set the path to the preview-images.
+  Default is: fileadmin/templates/preview/
+
+  * Folder for backend fluid templates (with ending slash). [basic.backend]
+ With mask you can style the backend preview of your content elements. Here you can set the path to your backend fluid templates.
+  Default is: fileadmin/templates/backend/

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,18 +1,2 @@
 # cat=general; type=file [json]; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-json
 json = typo3conf/mask.json
-
-# cat=frontend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-content
-content = fileadmin/templates/content/
-# cat=frontend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-layouts
-layouts = fileadmin/templates/content/Layouts/
-# cat=frontend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-partials
-partials = fileadmin/templates/content/Partials/
-
-# cat=backend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-backend
-backend = fileadmin/templates/backend/
-# cat=backend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-layouts_backend
-layouts_backend = fileadmin/templates/backend/Layouts/
-# cat=backend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-partials_backend
-partials_backend = fileadmin/templates/backend/Partials/
-# cat=backend; type=folder; label=LLL:EXT:mask/Resources/Private/Language/locallang_mask.xlf:ext_conf_template-preview
-preview = fileadmin/templates/preview/


### PR DESCRIPTION
**Request**
Find a good solution for [Forge Ticket](https://forge.typo3.org/issues/75312) Its a big topic and is a breaking change

**Changes**
- All $extSettings paths filled by settings service. This service was extend by two new getters:
  - frontendService
  - backendService
- JSON path is further available in ExtConf 
- Default mask path is set outside from fileadmin. fileadmin should filled by generated content?
- HTML Files for new elements would be saved in every path entry

**Individual paths**
You can control this paths with typoscript:

**Frontend**
<pre>
plugin.tx_mask {
  settings {
    feview {
      templateRootPaths.1 = templates2/content/
      partialRootPaths.1 = templates2/content/Partials/
      layoutRootPaths.1 = templates2/content/Layout/
    }
  }
}
</pre>

**Backend**
<pre>
module.tx_mask {
  settings {
    beview {
      templateRootPaths.1 = templates2/backend/
      partialRootPaths.1 = templates2/backend/Partials/
      layoutRootPaths.1 = templates2/backend/Layout/
      previewRootPaths.1 = templates2/preview/
      contentRootPaths.1 = templates2/content/      
    }
  }
}
</pre>