### PR TITLE
[BUGFIX]: TCA Exception for content elements in TYPO3 8.5.x. 

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,18 @@
+<?php
+
+$storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Repository\\StorageRepository');
+$configuration = $storageRepository->load();
+
+if (!empty($configuration)) {
+
+    $tcaCodeGenerator = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\CodeGenerator\\TcaCodeGenerator');
+
+    // Generate TCA for Pages
+    $pagesColumns = $tcaCodeGenerator->generateFieldsTca($configuration["pages"]["tca"]);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $pagesColumns);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', $pagesColumns);
+    $tcaCodeGenerator->setPageTca($configuration["pages"]["tca"]);
+
+    // Generate TCA for Inline-Fields
+    $tcaCodeGenerator->setInlineTca($configuration);
+}

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,7 +3,7 @@
 $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Repository\\StorageRepository');
 $configuration = $storageRepository->load();
 
-if (!empty($configuration)) {
+if (!empty($configuration) && array_key_exists('pages', $configuration)) {
 
     $tcaCodeGenerator = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\CodeGenerator\\TcaCodeGenerator');
 

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -10,3 +10,19 @@ if (!empty($GLOBALS['TCA']['tt_content']['columns']['CType']['config']['itemsPro
 // and set mask itemsProcFuncs
 $GLOBALS['TCA']['tt_content']['columns']['colPos']['config']['itemsProcFunc'] = 'MASK\Mask\ItemsProcFuncs\ColPosList->itemsProcFunc';
 $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['itemsProcFunc'] = 'MASK\Mask\ItemsProcFuncs\CTypeList->itemsProcFunc';
+
+$storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Repository\\StorageRepository');
+$configuration = $storageRepository->load();
+
+if (!empty($configuration)) {
+
+   $tcaCodeGenerator = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\CodeGenerator\\TcaCodeGenerator');
+
+   // Generate TCA for Content-Elements
+   $contentColumns = $tcaCodeGenerator->generateFieldsTca($configuration["tt_content"]["tca"]);
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $contentColumns);
+   $tcaCodeGenerator->setElementsTca($configuration["tt_content"]["elements"]);
+
+   // Generate TCA for Inline-Fields
+   $tcaCodeGenerator->setInlineTca($configuration);
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -14,7 +14,8 @@ $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['itemsProcFunc'] = '
 $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Repository\\StorageRepository');
 $configuration = $storageRepository->load();
 
-if (!empty($configuration)) {
+if (!empty($configuration) && array_key_exists('tt_content', $configuration)) {
+   \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump(array_key_exists('tt_content', $configuration));
 
    $tcaCodeGenerator = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\CodeGenerator\\TcaCodeGenerator');
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -32,28 +32,6 @@ if (TYPO3_MODE === 'BE') {
 }
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Mask');
 
-$storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Domain\\Repository\\StorageRepository');
-$configuration = $storageRepository->load();
-
-if (!empty($configuration)) {
-
-    $tcaCodeGenerator = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\CodeGenerator\\TcaCodeGenerator');
-
-    // Generate TCA for Content-Elements
-    $contentColumns = $tcaCodeGenerator->generateFieldsTca($configuration["tt_content"]["tca"]);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $contentColumns);
-    $tcaCodeGenerator->setElementsTca($configuration["tt_content"]["elements"]);
-
-    // Generate TCA for Pages
-    $pagesColumns = $tcaCodeGenerator->generateFieldsTca($configuration["pages"]["tca"]);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $pagesColumns);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', $pagesColumns);
-    $tcaCodeGenerator->setPageTca($configuration["pages"]["tca"]);
-
-    // Generate TCA for Inline-Fields
-    $tcaCodeGenerator->setInlineTca($configuration);
-}
-
 // include css for styling of backend preview of mask content elements
 $TBE_STYLES['skins']['mask']['name'] = 'mask';
 $TBE_STYLES['skins']['mask']['stylesheetDirectories'][] = 'EXT:mask/Resources/Public/Styles/Backend/';


### PR DESCRIPTION
Moved dynamic created TCA from ext_tables.php to TCA/Overrides tt_content and pages

In relation to: https://forge.typo3.org/issues/78957