### PR TITLE
Enhance selectbox handling

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -214,7 +214,7 @@ class GeneralUtility
     public function removeBlankOptions($haystack)
     {
         foreach ($haystack as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && $key !== 'items') {
                 $haystack[$key] = $this->removeBlankOptions($haystack[$key]);
             }
             if (empty($haystack[$key])) {

--- a/Resources/Public/Scripts/scripts.js
+++ b/Resources/Public/Scripts/scripts.js
@@ -154,14 +154,16 @@ jQuery(document).ready(function () {
 
 		// Checkbox items:
 		jQuery('.tx_mask_fieldcontent_items').each(function () {
+            var id = this.id;
 			itemArray = this.value.split('\n');
 			output = "";
 			jQuery.each(itemArray, function (key, line) {
 				lineArray = line.split(',');
 				output += '<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][items][' + key + '][0]" value="' + lineArray[0] + '" />';
-				if (lineArray[1] !== undefined) {
-					output += '<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][items][' + key + '][1]" value="' + lineArray[1].trim() + '" />';
-				}
+				if (id !== 'check_items') {
+					value = (lineArray[1] !== undefined) ? lineArray[1] : key.toString();
+					output += '<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][items][' + key + '][1]" value="' + value.trim() + '" />';
+                }
 			});
 			jQuery(this).parent().find(".tx_mask_fieldcontent_itemsresult").html(output);
 		});


### PR DESCRIPTION
This patch allows to define empty items for fields with items
configuration. This is useful for e.g. selectbox fields as the first
value may be empty to not force any default value.

Furthermore the JavaScript is changed to set the current line number
(key) for items if no value is defined. This is allows to only define
the labels in an items field and use the line numbers as their values.