### PR TITLE
[BUGFIX] Prevent SQL default value for datetime fields

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Datetime/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Datetime/Default.html
@@ -4,7 +4,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][size]" value="20" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][max]" value="20" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][exclude]" value="1" />
-<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="datetime DEFAULT '0000-00-00 00:00:00'" />
+<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="datetime" />
 <input type="hidden" name="tx_mask_tools_maskmask[dummy][--index--][datetime]" value="datetime" class="tx_mask_fieldcontent_eval" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][eval]" value="datetime" class="tx_mask_fieldcontent_evalresult" />
 


### PR DESCRIPTION
Setting default values for datetime fields is bound to the MySQL server
configuration. To be compatible to the default settings, this patch
removes default values for those fields.