### PR TITLE
[BUGFIX] Prevent html escaping in \MASK\Mask\ViewHelpers\LinkViewHelper

### DIFF
--- a/Classes/ViewHelpers/LinkViewHelper.php
+++ b/Classes/ViewHelpers/LinkViewHelper.php
@@ -14,6 +14,12 @@ namespace MASK\Mask\ViewHelpers;
  */
 class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
+    /**
+     * As this ViewHelper renders HTML, the output must not be escaped.
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
 
     /**
      * SettingsService


### PR DESCRIPTION
To be compatible with standalone fluid in TYPO3 8 we need to turn of the default
html ecaping.