### PR TITLE
[TASK] Remove MySQL default value for date field

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Date/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Date/Default.html
@@ -4,7 +4,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][size]" value="8" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][max]" value="20" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][exclude]" value="1" />
-<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="date DEFAULT '0000-00-00'" />
+<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="date" />
 <input type="hidden" name="tx_mask_tools_maskmask[dummy][--index--][date]" value="date" class="tx_mask_fieldcontent_eval" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][eval]" value="date" class="tx_mask_fieldcontent_evalresult" />
 


### PR DESCRIPTION
Defining a date field with DEFAULT '0000-00-00' leads to an 'invalid default value' error in MySQL 5.7 when Strict Mode/STRICT_TRANS_TABLES is set (which seems to be the default in 5.7).

See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict for details