### PR TITLE
[TASK] Fix colPos handling for inline content in repeater field

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -268,7 +268,7 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                         if ($fieldkey == "config" && $tcavalue[$fieldkey]["foreign_table"] == "tt_content") {
                             $tcavalue[$fieldkey]["foreign_field"] = $tcakey . "_parent";
                             if ($tcavalue["cTypes"]) {
-                                $tcavalue[$fieldkey]["foreign_record_defaults"]["CType"] = reset($tcavalue["cTypes"]);
+                                $tcavalue[$fieldkey]["overrideChildTca"]["columns"]["CType"]["config"]["default"] = reset($tcavalue["cTypes"]);
                             }
                         }
 

--- a/Resources/Private/Backend/Partials/Forms/Fields/Content/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Content/Default.html
@@ -4,7 +4,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="int(11) unsigned DEFAULT '0' NOT NULL" />
 
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][foreign_table]" value="tt_content" />
-<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][foreign_record_defaults][colPos]" value="999" />
+<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][overrideChildTca][columns][colPos][config][default]" value="999" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][foreign_sortby]" value="sorting" />
 
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][appearance][collapseAll]" value="1" />


### PR DESCRIPTION
In TYPO3 8.7 changing the colPos of inline content/tt_content elements to 999 (Mask Nested Content column) in a repeater field does not work anymore, the colPos always stays as is. Side effect is that the tt_content records appear in the page view in the backend.

The handling/definition of `foreign_record_defaults` config has changed within 8.7, see https://docs.typo3.org/typo3cms/extensions/core/8-dev/singlehtml/Index.html#deprecation-80000-inlineoverridechildtca for details.

The documentation says "A TCA auto-migration is in place." but this does not work on my testing enviroment with 8.7.0 and Mask master.