### PR TITLE
[Fix] fileUploadAllowed TCA handling

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -219,12 +219,12 @@ class TcaCodeGenerator extends AbstractCodeGenerator
 
 					 $customSettingOverride["appearance"] = $tcavalue["config"]["appearance"];
 					 if ($customSettingOverride["appearance"]["fileUploadAllowed"] == "") {
-						$customSettingOverride["appearance"]["fileUploadAllowed"] = "false";
+						$customSettingOverride["appearance"]["fileUploadAllowed"] = false;
 					 }
 					 if ($customSettingOverride["appearance"]["useSortable"] == "") {
-						$customSettingOverride["appearance"]["useSortable"] = "0";
+						$customSettingOverride["appearance"]["useSortable"] = 0;
 					 } else {
-						$customSettingOverride["appearance"]["useSortable"] = "1";
+						$customSettingOverride["appearance"]["useSortable"] = 1;
 					 }
 
 					 if ($tcavalue["config"]["filter"]["0"]["parameters"]["allowedFileExtensions"] != "") {

--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -217,7 +217,7 @@ class GeneralUtility
             if (is_array($value)) {
                 $haystack[$key] = $this->removeBlankOptions($haystack[$key]);
             }
-            if (empty($haystack[$key])) {
+            if( (is_array($haystack[$key]) && empty($haystack[$key])) || (is_string($haystack[$key]) && !strlen($haystack[$key])) ) {
                 unset($haystack[$key]);
             }
         }


### PR DESCRIPTION
The fileUploadAllowed TCA option currently is ignored due to its value being the string "false" instead of an expected boolean value.

Also correcting this issue needs fixing of GeneralUtility::removeBlankOptions().