### PR TITLE
[BUGFIX] Fix wrong backend handling of link field on re-edit

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Link/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Link/Default.html
@@ -3,6 +3,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][exclude]" value="1" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="tinytext" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][renderType]" value="inputLink" />
+<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][wizards][link][icon]" value="actions-wizard-link" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][softref]" value="typolink" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][fieldControl][linkPopup][options][title]" value="Link" />
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][fieldControl][linkPopup][options][windowOpenParameters]" class="tx_mask_fieldcontent_jsopenparams_result" value="height=300,width=500,status=0,menubar=0,scrollbars=1" />


### PR DESCRIPTION
This bug was fixed with bbbba60e981dcca6bcf0763e8d10e55dd7eff4eb but re-introduced with 4cb997c0f7a8ab817fbbd34eaa40ba1e782b44d5 since the following line was removed there:
`<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][wizards][link][icon]" value="actions-wizard-link" />`

This line has to be kept, otherwise the Mask module changes the TCA definition of a link field to a string field when re-editing and saving a Mask element with a link field in it.

See https://forge.typo3.org/issues/81182 for detailed description.