### PR TITLE
[FEATURE] Enforce cache clearing in save process

### DIFF
--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -24,6 +24,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  * ************************************************************* */
 
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * ^
  *
@@ -112,6 +115,10 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
    {
 	  // Update Database
 	  $this->sqlCodeGenerator->updateDatabase();
+
+	  // Clear system cache to force new TCA caching
+	  $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
+	  $cacheManager->flushCachesInGroup('system');
    }
 
    /**

--- a/Resources/Private/Backend/Templates/WizardContent/List.html
+++ b/Resources/Private/Backend/Templates/WizardContent/List.html
@@ -77,22 +77,4 @@
 		</div>
 	</div>
 
-
-	<div class="alert alert-info">
-		<div class="media">
-			<div class="media-left">
-				<span class="fa-stack fa-lg">
-					<i class="fa fa-circle fa-stack-2x"></i>
-					<i class="fa fa-info fa-stack-1x"></i>
-				</span>
-			</div>
-			<div class="media-body">
-				<h4 class="alert-title"><f:translate key="tx_mask.content.clear_cache.title"/></h4>
-				<div class="alert-message">
-					<f:translate key="tx_mask.content.clear_cache.message"/>
-				</div>
-			</div>
-		</div>
-	</div>
-
 </f:section>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -617,12 +617,6 @@
 			<trans-unit id="mask_content_colpos">
 				<target>Mask-Nested-Content</target>
 			</trans-unit>
-			<trans-unit id="tx_mask.content.clear_cache.title">
-				<target>Cache geleert?</target>
-			</trans-unit>
-			<trans-unit id="tx_mask.content.clear_cache.message">
-				<target>Dein neues Content-Element wird nicht angezeigt? Deine Änderungen wirken sich im Backend nicht aus? System-Cache leeren!</target>
-			</trans-unit>
 
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -613,12 +613,6 @@
 			<trans-unit id="mask_content_colpos">
 				<source>Mask-Nested-Content</source>
 			</trans-unit>
-			<trans-unit id="tx_mask.content.clear_cache.title">
-				<source>Cleared Cache?</source>
-			</trans-unit>
-			<trans-unit id="tx_mask.content.clear_cache.message">
-				<source>You don't see your new content element in the backend? Your changes are not shown? Clear the system caches!</source>
-			</trans-unit>
 
 		</body>
 	</file>


### PR DESCRIPTION
This patch triggers an automated cache clearing to enforce TCA
generation. The information alert in the list overview is removed.