### PR TITLE
[BUGFIX] Allow reuse of tab fields

### DIFF
--- a/Classes/Helper/FieldHelper.php
+++ b/Classes/Helper/FieldHelper.php
@@ -288,4 +288,38 @@ class FieldHelper
         }
         return $fieldType;
     }
+
+    /**
+     * Returns all fields of a type from a table
+     *
+     * @param string $key TCA Type
+     * @param string $type elementtype
+     * @return array fields
+     */
+    public function getFieldsByType($key, $type)
+    {
+        $storage = $this->storageRepository->load();
+        if (empty($storage[$type]) || empty($storage[$type]['tca'])) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ($storage[$type]['tca'] as $field => $config) {
+            if ($config['config']['type'] !== strtolower($key)) {
+                continue;
+            }
+
+            $elements = $this->getElementsWhichUseField($field, $type);
+            if (empty($elements)) {
+                continue;
+            }
+
+            $fields[] = [
+                'field' => $field,
+                'label' => $this->getLabel($elements[0]['key'], $field, $type),
+            ];
+        }
+
+        return $fields;
+    }
 }

--- a/Classes/ViewHelpers/TcaViewHelper.php
+++ b/Classes/ViewHelpers/TcaViewHelper.php
@@ -2,6 +2,9 @@
 
 namespace MASK\Mask\ViewHelpers;
 
+use MASK\Mask\Helper\FieldHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  *
  * Example
@@ -14,69 +17,114 @@ namespace MASK\Mask\ViewHelpers;
  */
 class TcaViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
-
     /**
      * FieldHelper
      *
      * @var \MASK\Mask\Helper\FieldHelper
-     * @inject
      */
     protected $fieldHelper;
 
     /**
+     * @var array
+     */
+    protected $forbiddenFields = [
+        'starttime',
+        'endtime',
+        'hidden',
+        'sectionIndex',
+        'linkToTop',
+        'fe_group',
+        'CType',
+        'doktype',
+        'title',
+        'TSconfig',
+        'php_tree_stop',
+        'storage_pid',
+        'tx_impexp_origuid',
+        't3ver_label',
+        'editlock',
+        'url_scheme',
+        'extendToSubpages',
+        'nav_title',
+        'nav_hide',
+        'subtitle',
+        'target',
+        'alias',
+        'url',
+        'urltype',
+        'lastUpdated',
+        'newUntil',
+        'cache_timeout',
+        'cache_tags',
+        'no_cache',
+        'no_search',
+        'shortcut',
+        'shortcut_mode',
+        'content_from_pid',
+        'mount_pid',
+        'keywords',
+        'description',
+        'abstract',
+        'author',
+        'author_email',
+        'is_siteroot',
+        'mount_pid_ol',
+        'module',
+        'fe_login_mode',
+        'l18n_cfg',
+        'backend_layout',
+        'backend_layout_next_level',
+        'tx_gridelements_children',
+    ];
+
+    /**
+     * @param FieldHelper $fieldHelper
+     */
+    public function __construct(FieldHelper $fieldHelper = null)
+    {
+        $this->fieldHelper = $fieldHelper ?? GeneralUtility::makeInstance('MASK\\Mask\\Helper\\FieldHelper');
+    }
+
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('type', 'string', 'Field type', true);
+        $this->registerArgument('table', 'string', 'Table name', true);
+    }
+
+    /**
      * Generates TCA Selectbox-Options-Array for a specific TCA-type.
      *
-     * @param string $type TCA Type
-     * @param string $table Tablename
      * @return array all TCA elements of this attribut
      * @author Gernot Ploiner <gp@webprofil.at>
      * @author Benjamin Butschell <bb@webprofil.at>
      */
-    public function render($type, $table)
+    public function render()
     {
-        $this->fieldHelper = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('MASK\\Mask\\Helper\\FieldHelper');
-        // in tt_content allow all fields except $forbiddenFields
-        if ($table == "tt_content") {
-            $forbiddenFields = array(
-                'starttime', 'endtime', 'hidden', 'sectionIndex', 'linkToTop', 'fe_group',
-                'CType', 'doktype', 'title', 'TSconfig', 'php_tree_stop', 'storage_pid',
-                'tx_impexp_origuid', 't3ver_label', 'editlock', 'url_scheme',
-                'extendToSubpages', 'nav_title', 'nav_hide', 'subtitle', 'target', 'alias',
-                'url', 'urltype', 'lastUpdated', 'newUntil', 'cache_timeout', 'cache_tags',
-                'no_cache', 'no_search', 'shortcut', 'shortcut_mode', 'content_from_pid',
-                'mount_pid', 'keywords', 'description', 'abstract', 'author',
-                'author_email', 'is_siteroot', 'mount_pid_ol', 'module', 'fe_login_mode',
-                'l18n_cfg', 'backend_layout', 'backend_layout_next_level', 'tx_gridelements_children'
-            );
-            foreach ($GLOBALS['TCA'][$table]['columns'] as $tcaField => $tcaConfig) {
-                $fieldType = $this->fieldHelper->getFormType($tcaField, "", $table);
-                if (
-                    ($fieldType == $type ||
-                    ($fieldType == "Text" &&
-                    ($type == "Text" || $type == "Richtext")
-                    )) && array_search($tcaField, $forbiddenFields) === FALSE
+        $table = $this->arguments['table'];
+        $type = $this->arguments['type'];
+
+        if (empty($GLOBALS['TCA'][$table])) {
+            return [];
+        }
+
+        $fields = [];
+        if ($table === 'tt_content' && $type !== 'Tab') {
+            foreach ($GLOBALS['TCA']['tt_content']['columns'] as $tcaField => $tcaConfig) {
+                $fieldType = $this->fieldHelper->getFormType($tcaField, '', $table);
+                if (($fieldType === $type || ($fieldType === 'Text' && $type === 'Richtext'))
+                    && !in_array($tcaField, $this->forbiddenFields, true)
                 ) {
-                    $temp["field"] = $tcaField;
-                    $temp["label"] = $tcaConfig["label"];
-                    $content[] = $temp;
+                    $fields[] = [
+                        'field' => $tcaField,
+                        'label' => $tcaConfig['label'],
+                    ];
                 }
             }
         } else {
-            // in pages allow only fields already created by mask
-            foreach ($GLOBALS['TCA'][$table]['columns'] as $tcaField => $tcaConfig) {
-                $fieldType = $this->fieldHelper->getFormType($tcaField, "", $table);
-                if (
-                    ($fieldType == $type ||
-                    ($fieldType == "Text" &&
-                    ($type == "Text" || $type == "Richtext")
-                    )) && strrpos($tcaField, "tx_mask_", -strlen($tcaField)) !== false
-                ) {
-                    $temp["field"] = $tcaField;
-                    $temp["label"] = $tcaConfig["label"];
-                    $content[] = $temp;
-                }
-            }
+            $fields = $this->fieldHelper->getFieldsByType($type, $table);
         }
-        return $content;
+
+        return $fields;
     }
 }


### PR DESCRIPTION
This patch allows the reuse of previously defined tab fields. As the
"Tab" type is not a valid TCA type, no column is found. Instead
mask should use its own storage for lookup,

Furthermore for tables other than tt_content, only mask columns are
allowed. To find proper columns, on storage information can be used too.