### PR TITLE
Replace forge links

### DIFF
--- a/Documentation/ToDoList/Index.rst
+++ b/Documentation/ToDoList/Index.rst
@@ -11,6 +11,6 @@
 To-Do list
 ==========
 
-If you are interested in our TODO-List, look into TYPO3-Forge:
-https://forge.typo3.org/projects/extension-mask
-Here you find an overview about bugs and featurewishes.
+If you are interested in our TODO-List, look into the issues on GitHub:
+
+* https://github.com/Gernott/mask/issues/

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Mask is a TYPO3 extension for creating content elements and extending page templ
 ## Next steps
 
 * Read how to install, configure and use mask in the [official documentation](https://docs.typo3.org/typo3cms/extensions/mask/)
-* Report bugs or suggest features in our [issue tracker](https://forge.typo3.org/projects/extension-mask)
+* Report bugs or suggest features in our [issue tracker](https://github.com/Gernott/mask/issues/)
 * [Join us on Slack](https://forger.typo3.org/slack) if you have any question about mask. Our channel is named _#ext-mask_

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"support": {
 		"source": "https://github.com/Gernott/mask",
 		"docs": "https://docs.typo3.org/typo3cms/extensions/mask/Index.html",
-		"issues": "https://forge.typo3.org/projects/extension-mask"
+		"issues": "https://github.com/Gernott/mask/issues/"
 	},
 	"keywords": ["TYPO3 CMS", "Mask", "Contentelements", "Wizard"],
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "http://mask.webprofil.at/",
 	"support": {
 		"source": "https://github.com/Gernott/mask",
-		"docs": "https://docs.typo3.org/typo3cms/extensions/mask/Index.html",
+		"docs": "https://docs.typo3.org/typo3cms/extensions/mask/",
 		"issues": "https://github.com/Gernott/mask/issues/"
 	},
 	"keywords": ["TYPO3 CMS", "Mask", "Contentelements", "Wizard"],


### PR DESCRIPTION
Simple PR - Just replaces all links to Forge with GitHub.