### PR TITLE
[TASK] composer.json: remove version field and use branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 		}
 	],
 	"license": "GPL-2.0-or-later",
-	"version": "3.1.1dev",
 	"require": {
 		"php": "^7.0",
 		"typo3/cms-core": "^8.7"
@@ -30,6 +29,11 @@
 	"autoload": {
 		"psr-4": {
 			"MASK\\Mask\\": "Classes/"
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "3.1.1dev"
 		}
 	}
 }


### PR DESCRIPTION
The version does not have to be specified in the file (anymore). It's easier to
omit the version field in composer.json. Packagist parses versions from tags
and branch names. New versions of your package are automatically fetched.

Tag/version names should match 'X.Y.Z', or 'vX.Y.Z', with an optional suffix for
RC, beta, alpha or patch versions. So it's fully ok to keep the prefixed "v1.2.3"
syntax.