### PR TITLE
[FEATURE] Add l10n_mode selection for all field types

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Config/Behaviour/LocalizationMode.html
+++ b/Resources/Private/Backend/Partials/Forms/Config/Behaviour/LocalizationMode.html
@@ -7,13 +7,17 @@
 		<select name="tx_mask_tools_maskmask[storage][tca][--index--][l10n_mode]" class="form-control"
 						title="levelLinksPosition">
 			<option {f:if(condition:
-			'{field.l10n_mode} == \'copy\'', then:'selected=selected')} value="copy">
-			<f:translate key="tx_mask.field.inline.l10n_mode.copy"/>
+			'{field.l10n_mode} == \'\'', then:'selected=selected')} value="">
+			<f:translate key="tx_mask.field.inline.l10n_mode.default"/>
 			</option>
-			<option {f:if(condition:
-			'{field.l10n_mode} == \'prefixLangTitle\'', then:'selected=selected')} value="prefixLangTitle">
-			<f:translate key="tx_mask.field.inline.l10n_mode.prefixLangTitle"/>
-			</option>
+			<f:if condition="{excludePrefixOption}">
+				<f:else>
+					<option {f:if(condition:
+					'{field.l10n_mode} == \'prefixLangTitle\'', then:'selected=selected')} value="prefixLangTitle">
+					<f:translate key="tx_mask.field.inline.l10n_mode.prefixLangTitle"/>
+					</option>
+				</f:else>
+			</f:if>
 			<option {f:if(condition:
 			'{field.l10n_mode} == \'exclude\'', then:'selected=selected')} value="exclude">
 			<f:translate key="tx_mask.field.inline.l10n_mode.exclude"/>

--- a/Resources/Private/Backend/Partials/Forms/Fields/Check/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Check/Tabs.html
@@ -1,4 +1,12 @@
 {namespace mask=MASK\Mask\ViewHelpers}
+
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Date/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Date/Tabs.html
@@ -44,3 +44,11 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode"
+				arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>

--- a/Resources/Private/Backend/Partials/Forms/Fields/Datetime/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Datetime/Tabs.html
@@ -44,3 +44,11 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode"
+				arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>

--- a/Resources/Private/Backend/Partials/Forms/Fields/Float/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Float/Tabs.html
@@ -18,7 +18,13 @@
 		</div>
 	</div>
 </div>
-
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Integer/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Integer/Tabs.html
@@ -18,6 +18,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Link/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Link/Tabs.html
@@ -57,6 +57,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="wizards_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Radio/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Radio/Tabs.html
@@ -1,4 +1,11 @@
 {namespace mask=MASK\Mask\ViewHelpers}
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Tabs.html
@@ -43,6 +43,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="wizards_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Select/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Select/Tabs.html
@@ -69,6 +69,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field, excludePrefixOption: 1}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/String/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/String/Tabs.html
@@ -51,6 +51,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="extended_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Fields/Text/Tabs.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Text/Tabs.html
@@ -43,6 +43,13 @@
 		</div>
 	</div>
 </div>
+<div role="tabpanel" class="tab-pane" id="localization_{key}">
+	<div class="row">
+		<div class="form-group col-sm-6">
+			<f:render partial="Forms/Config/Behaviour/LocalizationMode" arguments="{key:key, elementKey:storage.key, field: field}" />
+		</div>
+	</div>
+</div>
 <div role="tabpanel" class="tab-pane" id="wizards_{key}">
 	<div class="row">
 		<div class="form-group col-sm-6">

--- a/Resources/Private/Backend/Partials/Forms/Tabs/Tabheaders.html
+++ b/Resources/Private/Backend/Partials/Forms/Tabs/Tabheaders.html
@@ -1,46 +1,57 @@
 <f:switch expression="{type}">
 	<f:case value="String">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Float">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Integer">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Link">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Wizards" arguments="{key: key}"/>
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Date">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 	</f:case>
 	<f:case value="Datetime">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 	</f:case>
 	<f:case value="Text">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Wizards" arguments="{key: key}"/>
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Richtext">
 		<f:render partial="Forms/Tabs/Validation" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Wizards" arguments="{key: key}"/>
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Check">
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Radio">
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="Select">
 		<f:render partial="Forms/Tabs/Database" arguments="{key: key}"/>
 		<f:render partial="Forms/Tabs/Files" arguments="{key: key}"/>
+		<f:render partial="Forms/Tabs/Localization" arguments="{key: key}" />
 		<f:render partial="Forms/Tabs/Extended" arguments="{key: key}"/>
 	</f:case>
 	<f:case value="File">

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -239,8 +239,8 @@
 			<trans-unit id="tx_mask.field.inline.localization_mode">
 				<target>Lokalisierungs-Modus (l10n_mode)</target>
 			</trans-unit>
-			<trans-unit id="tx_mask.field.inline.l10n_mode.copy">
-				<target>Kopie (copy)</target>
+			<trans-unit id="tx_mask.field.inline.l10n_mode.default">
+				<target>Standard</target>
 			</trans-unit>
 			<trans-unit id="tx_mask.field.inline.l10n_mode.prefixLangTitle">
 				<target>Kopie mit Prefix (prefixLangTitle)</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -232,8 +232,8 @@
 			<trans-unit id="tx_mask.field.inline.localization_mode">
 				<source>Localization Mode (l10n_mode)</source>
 			</trans-unit>
-			<trans-unit id="tx_mask.field.inline.l10n_mode.copy">
-				<source>Create copy (copy)</source>
+			<trans-unit id="tx_mask.field.inline.l10n_mode.default">
+				<source>Default</source>
 			</trans-unit>
 			<trans-unit id="tx_mask.field.inline.l10n_mode.prefixLangTitle">
 				<source>Copy with prefix (prefixLangTitle)</source>


### PR DESCRIPTION
Adds the possibility to configure the localisation mode for all field types.
The copy mode is also renamed to "Default" and its value set to empty since it is no longer supported by typo3 v8.7.