### PR TITLE
Keep a changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Use `mb_substr` instead of `substr` to avoid encoding problems with German "umlauts". [#167](https://github.com/Gernott/mask/pull/167)
+
+
+[Unreleased]: https://github.com/Gernott/mask/compare/v3.3.1...master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Support TYPO3 v9. [#168](https://github.com/Gernott/mask/pull/168)
+- Link backend header of element to its edit page. [#159](https://github.com/Gernott/mask/pull/159)
+
+### Changed
+- Sort complete `mask.json` alphabetically to avoid merge conflicts. [#163](https://github.com/Gernott/mask/pull/163)
+
+### Removed
+- Support for TYPO3 v8 LTS was dropped. [#168](https://github.com/Gernott/mask/pull/168)
+
+### Fixed
+- Use `mb_substr` instead of `substr` to avoid encoding problems with German "umlauts". [#167](https://github.com/Gernott/mask/pull/167)


### PR DESCRIPTION
Quoting keepachangelog.com:

> # keep a changelog
> Don’t let your friends dump git logs into changelogs.
>
> ## What is a changelog? 
>  A changelog is a file which contains a curated, chronologically ordered list of notable changes for each version of a project.
>
> ## Why keep a changelog? 
> To make it easier for users and contributors to see precisely what notable changes have been made between each release (or version) of the project. 
>
> ## Who needs a changelog?
>  People do. Whether consumers or developers, the end users of software are human beings who care about what's in the software. When the software changes, people want to know why and how. 

See http://keepachangelog.com/en/1.0.0/ for more information.

For the new changelog I added already changes made after `3.3.1`.