### PR TITLE
Change default renderType value for checkboxes to the empty string

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Check/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Check/Default.html
@@ -43,7 +43,7 @@ option3"><mask:Items items="{field.config.items}"/></textarea>
 								title="{f:translate(key:'tx_mask.field.check.renderType')}"
 								class="form-control tx_mask_fieldcontent_eval tx_mask_fieldcontent_check_renderType">
 					<!-- @formatter:off -->
-					<option value="default" {f:if(condition:'{field.config.renderType} == \'default\'', then: ' selected="selected"')}>
+					<option value="" {f:if(condition:'{field.config.renderType} == \'\'', then: ' selected="selected"')}>
 						<f:translate key="tx_mask.field.check.renderType.default"/>
 					</option>
 					<option value="checkboxToggle" {f:if(condition:'{field.config.renderType} == \'checkboxToggle\'', then: ' selected="selected"')}>


### PR DESCRIPTION
If the renderType "default" is used, TYPO3 v9.5.0 displays an error message when it renders the backend form.

<img width="384" alt="firefox_2018-10-05_15-11-46" src="https://user-images.githubusercontent.com/8247577/46537886-bf0f8780-c8b2-11e8-9ab0-b739113fcf80.png">

The checkbox field type is the only instance of the renderType "default" being explicitly set.