### PR TITLE
Fix sorting of fields in an inline type

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -475,6 +475,12 @@ class TcaCodeGenerator extends AbstractCodeGenerator
         $prependTabs = "sys_language_uid, l10n_parent, l10n_diffsource, hidden, ";
         if ($tca) {
             $i = 0;
+            uasort($tca, function ($columnA, $columnB) {
+                $a = isset($columnA['order']) ? (int)$columnA['order'] : 0;
+                $b = isset($columnB['order']) ? (int)$columnB['order'] : 0;
+                return $a - $b;
+            });
+
             foreach ($tca as $fieldKey => $configuration) {
                 // check if this field is of type tab
                 $formType = $fieldHelper->getFormType($fieldKey, "", $table);
@@ -495,7 +501,7 @@ class TcaCodeGenerator extends AbstractCodeGenerator
         }
 
         // take first field for inline label
-        if ($fields) {
+        if (!empty($fields)) {
             $labelField = $generalUtility->getFirstNoneTabField($fields);
         }
 

--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -142,6 +142,11 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 if (is_array($field)) {
                     if ($field["config"]["type"] == "inline") {
                         $storage["tca"][$key]["inlineFields"] = $this->storageRepository->loadInlineFields($key);
+                        uasort($storage["tca"][$key]["inlineFields"], function ($columnA, $columnB) {
+                            $a = isset($columnA['order']) ? (int)$columnA['order'] : 0;
+                            $b = isset($columnB['order']) ? (int)$columnB['order'] : 0;
+                            return $a - $b;
+                        });
                     }
                 }
             }

--- a/Classes/Domain/Repository/StorageRepository.php
+++ b/Classes/Domain/Repository/StorageRepository.php
@@ -281,6 +281,11 @@ class StorageRepository
                 }
                 $json[$type]["tca"]["tx_mask_" . $columns[$key]] = $json[$type]["tca"][$columns[$key]];
                 $json[$type]["tca"]["tx_mask_" . $columns[$key]]["key"] = $columns[$key];
+
+                if ($inlineField) {
+                    $json[$type]["tca"]["tx_mask_" . $columns[$key]]["order"] = $key;
+                }
+
                 unset($json[$type]["tca"][$columns[$key]]);
             }
         }

--- a/Resources/Public/Scripts/scripts.js
+++ b/Resources/Public/Scripts/scripts.js
@@ -513,7 +513,6 @@ function initSortable() {
       }
     },
     stop: function (event, ui) {
-      initSortable();
       if (!sorted) {
         sortFields();
         sorted = true;


### PR DESCRIPTION
The drag & drop operaiton in the backend re-orders the form elements,
such that the iteration in the Mask storage update is in the correct
order, but that order is destroyed by sortJson. This fixed sorting is
valuable to version control, so instead this commit introduces an extra
field 'order' in the column of the inline type. This is used in the TCA
generator and before the backend view renders.

Additionally, I removed a superfluous initSortable call in the backend JavaScript.
The sortable widget has already been initialized, no need to re-initialize it
with some new functions that do exactly the same.