### PR TITLE
[BUGFIX] Fix invalid default value of date field

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Date/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Date/Default.html
@@ -4,7 +4,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][renderType]" value="inputDateTime"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][size]" value="8"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][exclude]" value="1"/>
-<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="date DEFAULT '0000-00-00'"/>
+<input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="date"/>
 <input type="hidden" name="tx_mask_tools_maskmask[dummy][--index--][date]" value="date"
 			 class="tx_mask_fieldcontent_eval"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][eval]" value="date"


### PR DESCRIPTION
'0000-00-00' is not a valid default value for a date field. This causes the Install Tool to fail when executing a database compare.
Instead, just default to NULL

According to the MySQL Manual: […] The supported range is '1000-01-01' to '9999-12-31’. […]
See: https://dev.mysql.com/doc/refman/5.7/en/datetime.html