### PR TITLE
[BUGFIX] #215: Migrate getRootline to RootlineUtility  …

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -152,7 +152,7 @@ if (!function_exists('user_mask_beLayout')) {
             } else { // If backend_layout and backend_layout_next_level is not set on current page, check backend_layout_next_level on rootline
                 $sysPage = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
                 try {
-                    $rootline = $sysPage->getRootLine($uid, '');
+                    $rootline = (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Utility\RootlineUtility::class, $uid))->get();
                 } catch (Exception $e) {
                     $rootline = [];
                 }


### PR DESCRIPTION
There are many new deprecations in TYPO3 9 and one of these is
PageRepository->getRootline(). This patch solves the issue by replacing
getRooline in ext_localconf.php with RootlineUtility.