### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
 	"require": {
 		"php": "^7.2",
 		"ext-json": "*",
-		"typo3/cms-core": ">=9.3.0 <9.5.99",
-		"typo3/cms-backend": ">=9.3.0 <9.5.99",
-		"typo3/cms-fluid": ">=9.3.0 <9.5.99",
-		"typo3/cms-extbase": ">=9.3.0 <9.5.99"
+		"typo3/cms-core": "^9.5",
+		"typo3/cms-backend": "^9.5",
+		"typo3/cms-fluid": "^9.5",
+		"typo3/cms-extbase": "^9.5"
 	},
 	"replace": {
 		"mask": "self.version",


### PR DESCRIPTION
At the moment you can't use mask/mask in combination with `"typo3/minimal": "9.5.x-dev"` as x-dev is higher than 99.