### PR TITLE
Add indexes to tt_content for parent fields

### DIFF
--- a/Classes/CodeGenerator/SqlCodeGenerator.php
+++ b/Classes/CodeGenerator/SqlCodeGenerator.php
@@ -180,7 +180,7 @@ class SqlCodeGenerator extends \MASK\Mask\CodeGenerator\AbstractCodeGenerator
                                         // if this field is a content field, also add parent columns
                                         $fieldType = $fieldHelper->getFormType($field, "", $table);
                                         if ($fieldType == "Content") {
-                                            $sql_content[] = "CREATE TABLE tt_content (\n\t" . $field . "_parent" . " " . $definition . "\n);\n";
+                                            $sql_content[] = "CREATE TABLE tt_content (\n\t" . $field . "_parent" . " " . $definition . ",\n\t" . "KEY " . $field . " (" . $field . "_parent,pid,deleted)" . "\n);\n";
                                         }
                                     }
                                 }


### PR DESCRIPTION
To speed up database queries an own index for each parent field is added to tt_content table.
