### PR TITLE
[BUGFIX] Fix TCA default value of field parentid for Inline-Tables

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -453,6 +453,7 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                         'foreign_table_where' =>
                             'AND tt_content.pid=###CURRENT_PID###
 								AND tt_content.sys_language_uid IN (-1,###REC_FIELD_sys_language_uid###)',
+                        'default' => 0
                     ),
                 ),
                 'parenttable' => array(


### PR DESCRIPTION
A default value is required by the DataHandler in order to guess the right field type,
and to send the right value to the database.
See `\TYPO3\CMS\Core\DataHandling\DataHandler::castReferenceValue()`

A wrong type can lead to SQL errors if the SQL server with strict_mode enabled.