### PR TITLE
[BUGFIX] Replace user_mask_contentType with symfony expression language function

### DIFF
--- a/Classes/CodeGenerator/TyposcriptCodeGenerator.php
+++ b/Classes/CodeGenerator/TyposcriptCodeGenerator.php
@@ -83,7 +83,7 @@ class TyposcriptCodeGenerator extends AbstractCodeGenerator
                     $content .= "}\n";
 
                     // and switch the labels depending on which content element is selected
-                    $content .= "\n[userFunc = user_mask_contentType(CType|mask_" . $element["key"] . ")]\n";
+                    $content .= "\n[isMaskContentType('" . $element['key'] . "')]\n";
                     if ($element["columns"]) {
                         foreach ($element["columns"] as $index => $column) {
                             $content .= " TCEFORM.tt_content." . $column . ".label = " . $element["labels"][$index] . "\n";

--- a/Classes/ExpressionLanguage/MaskContentTypeConditionFunctionsProvider.php
+++ b/Classes/ExpressionLanguage/MaskContentTypeConditionFunctionsProvider.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace MASK\Mask\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool as ConnectionPoolAlias;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction as DeletedRestrictionAlias;
+use TYPO3\CMS\Core\ExpressionLanguage\RequestWrapper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class MaskContentTypeConditionFunctionsProvider
+ *
+ * @package MASK\Mask\ExpressionLanguage
+ * @author Wolfgang Klinger <wk@plan2.net>
+ */
+class MaskContentTypeConditionFunctionsProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @return ExpressionFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            $this->getMaskContentElementFunction()
+        ];
+    }
+
+    /**
+     * @return ExpressionFunction
+     */
+    protected function getMaskContentElementFunction(): ExpressionFunction
+    {
+        $getContentElementType = static function (int $uid): string {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPoolAlias::class)
+                ->getQueryBuilderForTable('tt_content');
+            /** @var DeletedRestriction $deletedRestriction */
+            $deletedRestriction = GeneralUtility::makeInstance(DeletedRestrictionAlias::class);
+            $queryBuilder->getRestrictions()
+                ->removeAll()
+                ->add($deletedRestriction);
+
+            return (string)$queryBuilder->select('CType')
+                ->from('tt_content')
+                ->where($queryBuilder->expr()->eq('uid', $uid))
+                ->execute()
+                ->fetchColumn();
+        };
+
+        return new ExpressionFunction('isMaskContentType', static function () {
+            // Not implemented, we only use the evaluator
+        }, static function ($arguments, $value) use ($getContentElementType) {
+            static $contentTypeMappingCache = [];
+
+            /** @var RequestWrapper $request */
+            $request = $arguments['request'];
+            $requestParameters = $request->getQueryParams();
+            if (isset($requestParameters['edit']['tt_content']) &&
+                is_array($requestParameters['edit']['tt_content'])
+            ) {
+                $formType = (string)current($requestParameters['edit']['tt_content']);
+                $contentType = null;
+                // New record, content type (CType) given as request parameter
+                if ($formType === 'new' && isset($requestParameters['defVals']['tt_content']['CType'])) {
+                    $contentType = (string)$requestParameters['defVals']['tt_content']['CType'];
+                } else {
+                    // Existing record, fetch content type (CType) from database
+                    $uid = (int)key($requestParameters['edit']['tt_content']);
+                    $contentType = $contentTypeMappingCache[$uid] ?? $getContentElementType($uid);
+                }
+
+                return $contentType === 'mask_' . $value;
+            }
+
+            // Content element is loaded via ajax (inline)
+            $parsedBody = $request->getParsedBody();
+            if (isset($parsedBody['ajax']['context'])) {
+                $parsedContext = json_decode($parsedBody['ajax']['context'], true);
+                if (isset($parsedContext['config']['overrideChildTca']['columns']['CType']['config']['default'])) {
+                    return $parsedContext['config']['overrideChildTca']['columns']['CType']['config']['default'] === 'mask_' . $value;
+                }
+            }
+
+            return false;
+        });
+    }
+}

--- a/Classes/ExpressionLanguage/MaskContentTypeConditionProvider.php
+++ b/Classes/ExpressionLanguage/MaskContentTypeConditionProvider.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace MASK\Mask\ExpressionLanguage;
+
+use TYPO3\CMS\Core\ExpressionLanguage\AbstractProvider;
+use TYPO3\CMS\Core\ExpressionLanguage\RequestWrapper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class MaskContentType
+ *
+ * @package MASK\Mask\ExpressionLanguage
+ * @author Wolfgang Klinger <wk@plan2.net>
+ */
+class MaskContentTypeConditionProvider extends AbstractProvider
+{
+    public function __construct()
+    {
+        $this->expressionLanguageVariables = [
+            'request' => GeneralUtility::makeInstance(RequestWrapper::class, $GLOBALS['TYPO3_REQUEST'] ?? null),
+        ];
+        $this->expressionLanguageProviders[] = MaskContentTypeConditionFunctionsProvider::class;
+    }
+}

--- a/Configuration/ExpressionLanguage.php
+++ b/Configuration/ExpressionLanguage.php
@@ -1,0 +1,10 @@
+<?php
+
+defined('TYPO3_MODE') or die ('Access denied.');
+
+return [
+    // Add the condition provider to the 'typoscript' namespace
+    'typoscript' => [
+        \MASK\Mask\ExpressionLanguage\MaskContentTypeConditionProvider::class,
+    ]
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -49,54 +49,6 @@ $pageTs = $typoScriptCodeGenerator->generatePageTyposcript($configuration);
 $setupTs = $typoScriptCodeGenerator->generateSetupTyposcript($configuration, $settings);
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup($setupTs);
 
-// for conditions on tt_content
-if (!function_exists('user_mask_contentType')) {
-
-    function user_mask_contentType($param = "")
-    {
-        static $cTypeCache = [];
-
-        if (isset($_REQUEST["edit"]["tt_content"]) && is_array($_REQUEST["edit"]["tt_content"])) {
-            $field = explode("|", $param);
-            $request = $_REQUEST;
-            $first = array_shift($request["edit"]["tt_content"]);
-
-            if ($first == "new") { // if new element
-                if ($_REQUEST["defVals"]["tt_content"]["CType"] == $field[1]) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } else { // if element exists
-                $uid = intval(key($_REQUEST["edit"]["tt_content"]));
-
-                if (!isset($cTypeCache[$uid])) {
-                    /** @var \TYPO3\CMS\Core\Database\ConnectionPool $connection */
-                    $connection = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\ConnectionPool::class);
-                    $queryBuilder = $connection->getQueryBuilderForTable('tt_content');
-                    /** @var \TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction $deletedRestriction */
-                    $deletedRestriction = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction::class);
-                    $queryBuilder->getRestrictions()->removeAll()->add($deletedRestriction);
-                    $cTypeCache[$uid] = $queryBuilder->select($field[0])
-                        ->from('tt_content')
-                        ->where($queryBuilder->expr()->eq('uid', $uid))
-                        ->execute()
-                        ->fetchColumn(0);
-                }
-
-                return $cTypeCache[$uid] == $field[1];
-            }
-        } else {
-            // if content element is loaded by ajax, then it's ok
-            if (is_array($_REQUEST["ajax"])) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    }
-}
-
 // for conditions on the backend-layouts
 if (!function_exists('user_mask_beLayout')) {
 


### PR DESCRIPTION
Fixes issue #253

I know it's unlikely you'll merge this request because
a) I had no usage of user_mask_beLayout, so I didn't not (yet) change that too (samey) and
b) it works only for TYPO3 9 and newer PHP versions 
… but I hope this is an inspiration for how to do it and others who already want to use mask with TYPO3 9

