### PR TITLE
Makes hidden IRRE elements visible in the Backend

### DIFF
--- a/Classes/Helper/InlineHelper.php
+++ b/Classes/Helper/InlineHelper.php
@@ -30,6 +30,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\Inject;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 
 /**
  * Methods for working with inline fields (IRRE)
@@ -233,6 +234,12 @@ class InlineHelper
         }
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($childTable);
+        if(TYPO3_MODE=='BE'){
+            $queryBuilder
+                ->getRestrictions()
+                ->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        }
         $queryBuilder
             ->select('*')
             ->from($childTable)


### PR DESCRIPTION
For a faster overview you can view also the hidden sub datasets in the Backend Fluid Templates for each content element.