### PR TITLE
Add softref-config to rte fields

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -294,6 +294,10 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                             \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($columns[$tcakey],
                                 $tcavalue);
                         }
+                        
+                        if (isset($columns[$tcakey]['rte'])){
+                            $columns[$tcakey]['config']['softref'] = 'rtehtmlarea_images,typolink_tag,images,email[subst],url';
+                        }
 
                         // Unset some values that are not needed in TCA
                         unset($columns[$tcakey]["options"]);


### PR DESCRIPTION
Mask-RTE-Fields are missing the softref-config. You get no warning for example if you delete a file that is linked inside an rte-field.