### PR TITLE
Sort inline fields recursively for correct order of fields in editor

### DIFF
--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -163,11 +163,7 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 if (is_array($field)) {
                     if ($field["config"]["type"] == "inline") {
                         $storage["tca"][$key]["inlineFields"] = $this->storageRepository->loadInlineFields($key);
-                        uasort($storage["tca"][$key]["inlineFields"], function ($columnA, $columnB) {
-                            $a = isset($columnA['order']) ? (int)$columnA['order'] : 0;
-                            $b = isset($columnB['order']) ? (int)$columnB['order'] : 0;
-                            return $a - $b;
-                        });
+                        $this->sortInlineFieldsByOrder($storage["tca"][$key]["inlineFields"]);
                     }
                 }
             }
@@ -361,6 +357,28 @@ class WizardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 $path,
                 AbstractMessage::WARNING
             );
+        }
+    }
+
+    /**
+     * Sort inline fields recursively.
+     *
+     * @param array $inlineFields
+     */
+    public function sortInlineFieldsByOrder(array &$inlineFields)
+    {
+        uasort($inlineFields, function ($columnA, $columnB) {
+            $a = isset($columnA['order']) ? (int)$columnA['order'] : 0;
+            $b = isset($columnB['order']) ? (int)$columnB['order'] : 0;
+            return $a - $b;
+        });
+
+        foreach ($inlineFields as $i => $field) {
+            if ($field["config"]["type"] == "inline") {
+                if (isset($inlineFields[$i]["inlineFields"]) && is_array($inlineFields[$i]["inlineFields"])) {
+                    $this->sortInlineFieldsByOrder($inlineFields[$i]["inlineFields"]);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The fields within the "inner" repetition would always get sorted by key when re-opening the editor for the element.

![2020-03-19_233143](https://user-images.githubusercontent.com/1561831/77120760-e1ab4700-6a39-11ea-9f99-c5e5078ae9a1.png)

1. Order the fields (fieldb1, fieldb2, fieldb3) in a non-alphabetical order, like shown in the screenshot.
2. Save and close the editor for the content element.
3. Open the content element again in the editor - the fields are now incorrectly sorted alphabetical by their key (the json contains the correct order values though).
4. Saving again with the now incorrect order of the fields, breaks the previously stored order values.

This patch fixes the issue.