### PR TITLE
Enable softref f. Richtext-Fields in mask.json

### DIFF
--- a/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Default.html
@@ -8,6 +8,7 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][richtextConfiguration]"
 			 value="default"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][enableRichtext]" value="1"/>
+<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][softref]" value="rtehtmlarea_images,typolink_tag,images,email[subst],url"/>
 
 <div class="row">
 	<div class="form-group col-sm-6">


### PR DESCRIPTION
Add softref-config to mask-json for Richtext-Fields.
I think this is the better solution than my last PR.