### PR TITLE
[BUGFIX] Remove deprecated second argument for backend routes

### DIFF
--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -220,7 +220,7 @@ class WizardController extends ActionController
      * @throws Exception
      * @noinspection PhpUnused
      */
-    public function checkFieldKey(ServerRequest $request, Response $response): Response
+    public function checkFieldKey(ServerRequest $request): Response
     {
         $queryParams = $request->getQueryParams();
         $fieldKey = $queryParams['key'];
@@ -246,7 +246,7 @@ class WizardController extends ActionController
      * @throws Exception
      * @noinspection PhpUnused
      */
-    public function checkElementKey(ServerRequest $request, Response $response = null): Response
+    public function checkElementKey(ServerRequest $request): Response
     {
         $elementKey = $request->getQueryParams()['key'];
 


### PR DESCRIPTION
The second argument for backend routes has been deprecated since v9.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/58190/
Resolves: #293