### PR TITLE
Remove parseFuncTSPath="lib.parseFunc_RTE" in f:format.html

### DIFF
--- a/Classes/CodeGenerator/HtmlCodeGenerator.php
+++ b/Classes/CodeGenerator/HtmlCodeGenerator.php
@@ -141,7 +141,7 @@ class HtmlCodeGenerator extends AbstractCodeGenerator
                 break;
             case 'Richtext':
                 $html .= '<f:if condition="{' . $datafield . '.' . $fieldKey . '}">' . "\n";
-                $html .= '<f:format.html parseFuncTSPath="lib.parseFunc_RTE">{' . $datafield . '.' . $fieldKey . '}</f:format.html><br />' . "\n";
+                $html .= '<f:format.html>{' . $datafield . '.' . $fieldKey . '}</f:format.html><br />' . "\n";
                 $html .= "</f:if>\n\n";
                 break;
             case 'Text':


### PR DESCRIPTION
This is the default value for f:format.html