### PR TITLE
[TASK] Remove setting the richtextConfiguration to default in tca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [5.1.0-dev]
+- Remove richtextConfiguration settings in tca. **NOTE:** It is necessary to save the mask elements which have richtext fields in order to apply this change.
+
 ## [5.0.0] - 2020-04-28
 
 ### Added

--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -143,7 +143,6 @@ class TcaCodeGenerator extends AbstractCodeGenerator
                     $fields = implode(',', $fieldArray);
 
                     $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['mask_' . $elementvalue['key']] = 'mask-ce-' . $elementvalue['key'];
-                    $GLOBALS['TCA']['tt_content']['types']['mask_' . $elementvalue['key']]['columnsOverrides']['bodytext']['config']['richtextConfiguration'] = 'default';
                     $GLOBALS['TCA']['tt_content']['types']['mask_' . $elementvalue['key']]['columnsOverrides']['bodytext']['config']['enableRichtext'] = 1;
                     $GLOBALS['TCA']['tt_content']['types']['mask_' . $elementvalue['key']]['showitem'] = $prependTabs . $fields . $defaultTabs . $gridelements;
                 }

--- a/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Default.html
+++ b/Resources/Private/Backend/Partials/Forms/Fields/Richtext/Default.html
@@ -5,8 +5,6 @@
 <input type="hidden" name="tx_mask_tools_maskmask[storage][sql][{type}][--index--]" value="mediumtext"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][eval]" value=""
 			 class="tx_mask_fieldcontent_evalresult"/>
-<input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][richtextConfiguration]"
-			 value="default"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][enableRichtext]" value="1"/>
 <input type="hidden" name="tx_mask_tools_maskmask[storage][tca][--index--][config][softref]" value="rtehtmlarea_images,typolink_tag,images,email[subst],url"/>
 


### PR DESCRIPTION
In TYPO3 v10 the order was changed in which richtext configuration is
overridden. Tca now has precedence over RTE.default.preset. Remove the
explicit setting of richtextConfiguration as default as this is the
default anyway.

Note: It is necessary to save the mask elements which have richtext
fields in order to apply this change.

Resolves: #284
Resolves: #281