### PR TITLE
[BUGFIX] Fix order of fields and tabs defined for backend layouts

### DIFF
--- a/Classes/CodeGenerator/AbstractCodeGenerator.php
+++ b/Classes/CodeGenerator/AbstractCodeGenerator.php
@@ -56,4 +56,12 @@ abstract class AbstractCodeGenerator
             $this->storageRepository = $storageRepository;
         }
     }
+
+    /**
+     * @return StorageRepository
+     */
+    public function getStorageRepository(): StorageRepository
+    {
+        return $this->storageRepository;
+    }
 }

--- a/Classes/CodeGenerator/TyposcriptCodeGenerator.php
+++ b/Classes/CodeGenerator/TyposcriptCodeGenerator.php
@@ -100,42 +100,6 @@ class TyposcriptCodeGenerator extends AbstractCodeGenerator
     }
 
     /**
-     * Generates the typoscript for pages
-     * @param array $json
-     * @return string
-     */
-    public function generatePageTyposcript($json): string
-    {
-        $pageColumns = [];
-        $disableColumns = '';
-        $pagesContent = '';
-        if ($json['pages']['elements']) {
-            foreach ($json['pages']['elements'] as $element) {
-                // Labels for pages
-                $pagesContent .= "\n[maskBeLayout('" . $element['key'] . "')]\n";
-                // if page has backendlayout with this element-key
-                if ($element['columns']) {
-                    foreach ($element['columns'] as $index => $column) {
-                        $pagesContent .= ' TCEFORM.pages.' . $column . '.label = ' . $element['labels'][$index] . "\n";
-                    }
-                    $pagesContent .= "\n";
-                    foreach ($element['columns'] as $index => $column) {
-                        $pageColumns[] = $column;
-                        $pagesContent .= ' TCEFORM.pages.' . $column . ".disabled = 0\n";
-                    }
-                }
-                $pagesContent .= "[end]\n";
-            }
-        }
-        // disable all fields by default and only activate by condition
-        foreach ($pageColumns as $column) {
-            $disableColumns .= 'TCEFORM.pages.' . $column . ".disabled = 1\n";
-        }
-        $pagesContent = $disableColumns . "\n" . $pagesContent;
-        return $pagesContent;
-    }
-
-    /**
      * Generates the typoscript for the setup field
      * @param array $configuration
      * @param array $settings

--- a/Classes/Domain/Repository/StorageRepository.php
+++ b/Classes/Domain/Repository/StorageRepository.php
@@ -79,9 +79,13 @@ class StorageRepository
     /**
      * is called before every action
      */
-    public function __construct()
+    public function __construct(SettingsService $settingsService = null)
     {
-        $this->settingsService = GeneralUtility::makeInstance(SettingsService::class);
+        if ($settingsService) {
+            $this->settingsService = $settingsService;
+        } else {
+            $this->settingsService = GeneralUtility::makeInstance(SettingsService::class);
+        }
         $this->extSettings = $this->settingsService->get();
     }
 

--- a/Classes/ExpressionLanguage/MaskFunctionsProvider.php
+++ b/Classes/ExpressionLanguage/MaskFunctionsProvider.php
@@ -3,10 +3,8 @@ declare(strict_types=1);
 
 namespace MASK\Mask\ExpressionLanguage;
 
-use Doctrine\DBAL\FetchMode;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
-use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;

--- a/Classes/Form/FormDataProvider/TcaTypesShowitemMaskBeLayoutFields.php
+++ b/Classes/Form/FormDataProvider/TcaTypesShowitemMaskBeLayoutFields.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MASK\Mask\Form\FormDataProvider;
+
+use MASK\Mask\CodeGenerator\TcaCodeGenerator;
+use TYPO3\CMS\Backend\Configuration\TypoScript\ConditionMatching\ConditionMatcher;
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class TcaTypesShowitemMaskBeLayoutFields implements FormDataProviderInterface
+{
+    public function addData(array $result)
+    {
+        $tcaCodeGenerator = GeneralUtility::makeInstance(TcaCodeGenerator::class);
+        $json = $tcaCodeGenerator->getStorageRepository()->load();
+        if ($json['pages']['elements'] ?? false) {
+            $conditionMatcher = GeneralUtility::makeInstance(ConditionMatcher::class, null, $result['vanillaUid'], $result['rootline']);
+            foreach ($json['pages']['elements'] as $element) {
+                $key = $element['key'];
+                if ($conditionMatcher->match("[maskBeLayout($key)]")) {
+                    $result['processedTca']['types'][$result['recordTypeValue']]['showitem'] .= $tcaCodeGenerator->getPageTca($key);
+                    break;
+                }
+            }
+        }
+        return $result;
+    }
+}

--- a/Classes/Helper/FieldHelper.php
+++ b/Classes/Helper/FieldHelper.php
@@ -129,16 +129,16 @@ class FieldHelper
         }
 
         // load tca for field from $GLOBALS
-        $tca = $GLOBALS['TCA'][$type]['columns'][$fieldKey];
-        if (!$tca['config']) {
-            $tca = $GLOBALS['TCA'][$type]['columns']['tx_mask_' . $fieldKey];
+        $tca = $GLOBALS['TCA'][$type]['columns'][$fieldKey] ?? [];
+        if (array_key_exists('config', $tca) && !$tca['config']) {
+            $tca = $GLOBALS['TCA'][$type]['columns']['tx_mask_' . $fieldKey] ?? [];
         }
-        if (!$tca['config']) {
-            $tca = $element['tca'][$fieldKey];
+        if (array_key_exists('config', $tca) && !$tca['config']) {
+            $tca = $element['tca'][$fieldKey] ?? [];
         }
 
         // if field is in inline table or $GLOBALS["TCA"] is not yet filled, load tca from json
-        if ($tca === null || !in_array($type, ['tt_content', 'pages'])) {
+        if (!$tca || !in_array($type, ['tt_content', 'pages'])) {
             $tca = $this->storageRepository->loadField($type, $fieldKey);
             if (!$tca['config']) {
                 $tca = $this->storageRepository->loadField($type, 'tx_mask_' . $fieldKey);
@@ -152,7 +152,7 @@ class FieldHelper
         }
 
 
-        if ($tca['options'] === 'file') {
+        if (($tca['options'] ?? '') === 'file') {
             $formType = 'File';
         }
 

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -11,7 +11,6 @@ if (!empty($configuration) && array_key_exists('pages', $configuration)) {
     // Generate TCA for Pages
     $pagesColumns = $tcaCodeGenerator->generateFieldsTca($configuration['pages']['tca']);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $pagesColumns);
-    $tcaCodeGenerator->setPageTca($configuration['pages']['tca']);
 
     // Generate TCA for Inline-Fields
     $tcaCodeGenerator->setInlineTca($configuration);

--- a/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
+++ b/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace MASK\Mask\Test\CodeGenerator;
+
+use MASK\Mask\CodeGenerator\TcaCodeGenerator;
+use MASK\Mask\Domain\Repository\StorageRepository;
+use MASK\Mask\Domain\Service\SettingsService;
+use MASK\Mask\Helper\FieldHelper;
+use TYPO3\TestingFramework\Core\BaseTestCase;
+
+class TcaCodeGeneratorTest extends BaseTestCase
+{
+    /**
+     * @return array[]
+     **/
+    public function getPageTcaDataProvider()
+    {
+        return [
+            'Layout 1 is rendered in correct order' => [
+                [
+                    'pages' => [
+                        'elements' => [
+                            '1' => [
+                                'columns' => [
+                                    'tx_mask_c_in_default_tab',
+                                    'tx_mask_b_tab',
+                                    'tx_mask_b_in_b_tab',
+                                    'tx_mask_a_tab',
+                                    'tx_mask_a_in_a_tab'
+                                ],
+                                'label' => 'Backend Layout 1',
+                                'description' => 'Test backend layout',
+                                'shortLabel' => 'BL 1',
+                                'key' => '1',
+                                'labels' => [
+                                    'In Standard Tab',
+                                    'B Tab',
+                                    'B Feld',
+                                    'A Tab',
+                                    'A Feld'
+                                ],
+                            ],
+                            '2' => [
+                                'columns' => [
+                                    'tx_mask_d_in_default_tab',
+                                    'tx_mask_c_in_default_tab'
+                                ],
+                                'label' => 'Backend Layout 2',
+                                'description' => 'Test backend layout 2',
+                                'shortLabel' => 'BL 2',
+                                'key' => '2',
+                                'labels' => [
+                                    'In Standard Tab',
+                                    'In Stamdard Tab 2',
+                                ],
+                            ]
+                        ],
+                        'tca' => [
+                            'tx_mask_a_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'a_tab'
+                            ],
+                            'tx_mask_a_in_a_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'a_in_a_tab'
+                            ],
+                            'tx_mask_b_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'b_tab'
+                            ],
+                            'tx_mask_b_in_b_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'b_in_b_tab'
+                            ],
+                            'tx_mask_c_in_default_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'c_in_default_tab'
+                            ],
+                            'tx_mask_d_in_default_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'd_in_default_tab'
+                            ],
+                        ]
+                    ]
+                ],
+                '1',
+                ',--div--;Content-Fields,tx_mask_c_in_default_tab,--div--;B Tab,tx_mask_b_in_b_tab,--div--;A Tab,tx_mask_a_in_a_tab',
+            ],
+            'Layout 2 is rendered in correct order' => [
+                [
+                    'pages' => [
+                        'elements' => [
+                            '1' => [
+                                'columns' => [
+                                    'tx_mask_c_in_default_tab',
+                                    'tx_mask_b_tab',
+                                    'tx_mask_b_in_b_tab',
+                                    'tx_mask_a_tab',
+                                    'tx_mask_a_in_a_tab'
+                                ],
+                                'label' => 'Backend Layout 1',
+                                'description' => 'Test backend layout',
+                                'shortLabel' => 'BL 1',
+                                'key' => '1',
+                                'labels' => [
+                                    'In Standard Tab',
+                                    'B Tab',
+                                    'B Feld',
+                                    'A Tab',
+                                    'A Feld'
+                                ],
+                            ],
+                            '2' => [
+                                'columns' => [
+                                    'tx_mask_d_in_default_tab',
+                                    'tx_mask_c_in_default_tab'
+                                ],
+                                'label' => 'Backend Layout 2',
+                                'description' => 'Test backend layout 2',
+                                'shortLabel' => 'BL 2',
+                                'key' => '2',
+                                'labels' => [
+                                    'In Standard Tab',
+                                    'In Stamdard Tab 2',
+                                ],
+                            ]
+                        ],
+                        'tca' => [
+                            'tx_mask_a_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'a_tab'
+                            ],
+                            'tx_mask_a_in_a_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'a_in_a_tab'
+                            ],
+                            'tx_mask_b_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'b_tab'
+                            ],
+                            'tx_mask_b_in_b_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'b_in_b_tab'
+                            ],
+                            'tx_mask_c_in_default_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'c_in_default_tab'
+                            ],
+                            'tx_mask_d_in_default_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'd_in_default_tab'
+                            ],
+                        ]
+                    ]
+                ],
+                '2',
+                ',--div--;Content-Fields,tx_mask_d_in_default_tab,tx_mask_c_in_default_tab',
+            ],
+            'If tab is at first place override default tab' => [
+                [
+                    'pages' => [
+                        'elements' => [
+                            '1' => [
+                                'columns' => [
+                                    'tx_mask_b_tab',
+                                    'tx_mask_b_in_b_tab',
+                                    'tx_mask_a_tab',
+                                    'tx_mask_a_in_a_tab'
+                                ],
+                                'label' => 'Backend Layout 1',
+                                'description' => 'Test backend layout',
+                                'shortLabel' => 'BL 1',
+                                'key' => '1',
+                                'labels' => [
+                                    'B Tab',
+                                    'B Feld',
+                                    'A Tab',
+                                    'A Feld'
+                                ],
+                            ]
+                        ],
+                        'tca' => [
+                            'tx_mask_a_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'a_tab'
+                            ],
+                            'tx_mask_a_in_a_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'a_in_a_tab'
+                            ],
+                            'tx_mask_b_tab' => [
+                                'config' => [
+                                    'type' => 'tab',
+                                ],
+                                'key' => 'b_tab'
+                            ],
+                            'tx_mask_b_in_b_tab' => [
+                                'config' => [
+                                    'type' => 'input',
+                                ],
+                                'key' => 'b_in_b_tab'
+                            ],
+                        ]
+                    ]
+                ],
+                '1',
+                ',--div--;B Tab,tx_mask_b_in_b_tab,--div--;A Tab,tx_mask_a_in_a_tab',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider getPageTcaDataProvider
+     */
+    public function getPageTca($json, $key, $expected)
+    {
+        $settingsService = $this->getMockBuilder(SettingsService::class)->getMock();
+        $storage = $this->getMockBuilder(StorageRepository::class)
+            ->setConstructorArgs([$settingsService])
+            ->onlyMethods(['load'])
+            ->getMock();
+
+        $storage->method('load')->willReturn($json);
+        $fieldHelper = new FieldHelper($storage);
+        $tcaGenerator = new TcaCodeGenerator($storage, $fieldHelper);
+        $this->assertSame($expected, $tcaGenerator->getPageTca($key));
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -39,9 +39,7 @@ defined('TYPO3_MODE') or die();
 
     // Add all the typoscript we need in the correct files
     $tsConfig = $typoScriptCodeGenerator->generateTsConfig($configuration);
-    $pageTs = $typoScriptCodeGenerator->generatePageTyposcript($configuration);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig($tsConfig);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig($pageTs);
 
     $setupTs = $typoScriptCodeGenerator->generateSetupTyposcript($configuration, $settings);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup($setupTs);
@@ -71,5 +69,13 @@ defined('TYPO3_MODE') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['tt_content_drawItem'][$extkey] = \MASK\Mask\Hooks\PageLayoutViewDrawItem::class;
     // Hook to override colpos check for unused tt_content elements
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['record_is_used'] [] = MASK\Mask\Hooks\PageLayoutViewHook::class . '->contentIsUsed';
-    
+    // Extend Page Tca Fields specific for backend layout
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][MASK\Mask\Form\FormDataProvider\TcaTypesShowitemMaskBeLayoutFields::class] = [
+        'depends' => [
+            \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordTypeValue::class
+        ],
+        'before' => [
+            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class
+        ]
+    ];
 })('mask');


### PR DESCRIPTION
The problem was that the order of showitem was taken from the mask tca
array instead of columns. This was necessary because backend layouts
can share fields and the order may vary. Now, instead of creating the
whole showitem string for all fields, we extend the showitem for the
specific page type and backend layout just before the tca is processed
with the help of a FormDataProvider. This way it is possible to use the
predefined order of fields and tabs.

Resolves: #214