### PR TITLE
[BUGFIX] Add single quotes to Typoscript condition

### DIFF
--- a/Classes/Form/FormDataProvider/TcaTypesShowitemMaskBeLayoutFields.php
+++ b/Classes/Form/FormDataProvider/TcaTypesShowitemMaskBeLayoutFields.php
@@ -19,7 +19,7 @@ class TcaTypesShowitemMaskBeLayoutFields implements FormDataProviderInterface
             $conditionMatcher = GeneralUtility::makeInstance(ConditionMatcher::class, null, $result['vanillaUid'], $result['rootline']);
             foreach ($json['pages']['elements'] as $element) {
                 $key = $element['key'];
-                if ($conditionMatcher->match("[maskBeLayout($key)]")) {
+                if ($conditionMatcher->match("[maskBeLayout('".$key."')]")) {
                     $result['processedTca']['types'][$result['recordTypeValue']]['showitem'] .= $tcaCodeGenerator->getPageTca($key);
                     break;
                 }


### PR DESCRIPTION
Mon, 10 Aug 2020 10:37:15 +0000 [ERROR] request="beca54c9e278a" component="TYPO3.CMS.Backend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Expression could not be parsed. - {"expression":"maskBeLayout(default)"}

(PHP 7.4.9, TYPO3 10.4.6)