### PR TITLE
[BUGFIX] Do not allow having Content fields with same key

### DIFF
--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -228,7 +228,11 @@ class WizardController extends ActionController
         }
 
         if ($type !== 'Inline') {
-            $fieldExists = $this->storageRepository->loadField($table, $fieldKey);
+            if ($type === 'Content') {
+                $fieldExists = $this->fieldHelper->getFieldType($fieldKey);
+            } else {
+                $fieldExists = $this->storageRepository->loadField($table, $fieldKey);
+            }
         }
 
         return new JsonResponse(['isAvailable' => !$keyExists && !$fieldExists]);


### PR DESCRIPTION
To avoid naming conflicts, it is not allowed to have Content fields
with the same key, even if they are located in repeating fields.

Fixes: #199