### PR TITLE
[BUGFIX] Cast return value to string

### DIFF
--- a/Classes/ViewHelpers/TranslateLabelViewHelper.php
+++ b/Classes/ViewHelpers/TranslateLabelViewHelper.php
@@ -51,7 +51,7 @@ class TranslateLabelViewHelper extends AbstractViewHelper
         }
 
         if (empty($key) || strpos($key, 'LLL') > 0) {
-            return $key;
+            return (string)$key;
         }
 
         $request = $this->renderingContext->getControllerContext()->getRequest();


### PR DESCRIPTION
Key might not be a string but return type forces it to be one, so do a type cast