### PR TITLE
[BUGFIX] Fetch workspace ID from context API

### DIFF
--- a/Classes/Helper/InlineHelper.php
+++ b/Classes/Helper/InlineHelper.php
@@ -252,7 +252,7 @@ class InlineHelper
                 ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         }
         if (BackendUtility::isTableWorkspaceEnabled($childTable)) {
-            $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, (int)$GLOBALS['BE_USER']->workspace));
+            $queryBuilder->getRestrictions()->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('workspace', 'id')));
         }
         $queryBuilder
             ->select('*')


### PR DESCRIPTION
In a project (11.5.x-dev, PHP 8.1) the GLOBALS['BE_USER'] object is unset in the frontend request resulting in a PHP error message when calling the frontend with mask inline elements. In newer TYPO3 versions, the corresponding properties ('workspace' in this case) should be fetched from the Context API. That's what the change does.