### PR TITLE
[FEATURE] Add a PSR-14 event to manipulate data in the $allowedFields array

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -28,9 +28,11 @@ use MASK\Mask\Domain\Repository\BackendLayoutRepository;
 use MASK\Mask\Domain\Repository\StorageRepository;
 use MASK\Mask\Enumeration\FieldType;
 use MASK\Mask\Enumeration\Tab;
+use MASK\Mask\Event\MaskAllowedFieldsEvent;
 use MASK\Mask\Loader\LoaderInterface;
 use MASK\Mask\Utility\AffixUtility;
 use MASK\Mask\Utility\TemplatePathUtility;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\BackendLayout\BackendLayout;
@@ -72,6 +74,7 @@ class AjaxController
     protected OnlineMediaHelperRegistry $onlineMediaHelperRegistry;
     protected TableDefinitionCollection $tableDefinitionCollection;
     protected LoaderInterface $loader;
+    protected EventDispatcherInterface $eventDispatcher;
 
     /**
      * @var array<string, string>
@@ -102,6 +105,7 @@ class AjaxController
         OnlineMediaHelperRegistry $onlineMediaHelperRegistry,
         TableDefinitionCollection $tableDefinitionCollection,
         LoaderInterface $loader,
+        EventDispatcherInterface $eventDispatcher,
         array $maskExtensionConfiguration
     ) {
         $this->storageRepository = $storageRepository;
@@ -115,6 +119,7 @@ class AjaxController
         $this->tableDefinitionCollection = $tableDefinitionCollection;
         $this->maskExtensionConfiguration = $maskExtensionConfiguration;
         $this->loader = $loader;
+        $this->eventDispatcher = $eventDispatcher;
         $this->flashMessageQueue = new FlashMessageQueue('mask');
     }
 
@@ -624,6 +629,12 @@ class AjaxController
                 'category_field',
             ],
         ];
+
+        /** @var MaskAllowedFieldsEvent $allowedFieldsEvent */
+        $allowedFieldsEvent = $this->eventDispatcher->dispatch(
+            new MaskAllowedFieldsEvent($allowedFields)
+        );
+        $allowedFields = $allowedFieldsEvent->getAllowedFields();
 
         $table = $request->getQueryParams()['table'];
         $type = $request->getQueryParams()['type'];

--- a/Classes/Event/MaskAllowedFieldsEvent.php
+++ b/Classes/Event/MaskAllowedFieldsEvent.php
@@ -19,14 +19,18 @@ namespace MASK\Mask\Event;
 
 final class MaskAllowedFieldsEvent
 {
+    /**
+     * @var array<string, list<string>>
+     */
     private array $allowedFields;
 
-    public function __construct(array $allowedFields) {
+    public function __construct(array $allowedFields)
+    {
         $this->allowedFields = $allowedFields;
     }
 
     /**
-     * @return array
+     * @return array<string, list<string>>
      */
     public function getAllowedFields(): array
     {
@@ -34,10 +38,21 @@ final class MaskAllowedFieldsEvent
     }
 
     /**
-     * @param array $allowedFields
+     * @param array<string, list<string>> $allowedFields
      */
     public function setAllowedFields(array $allowedFields): void
     {
         $this->allowedFields = $allowedFields;
+    }
+
+    public function addField(string $fieldName, string $table = 'tt_content'): void
+    {
+        $this->allowedFields[$table][] = $fieldName;
+    }
+
+    public function removeField(string $fieldName, string $table = 'tt_content'): void
+    {
+        $position = array_search($fieldName, $this->allowedFields[$table]);
+        array_splice($this->allowedFields[$table], $position, 1);
     }
 }

--- a/Classes/Event/MaskAllowedFieldsEvent.php
+++ b/Classes/Event/MaskAllowedFieldsEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace MASK\Mask\Event;
+
+final class MaskAllowedFieldsEvent
+{
+    private array $allowedFields;
+
+    public function __construct(array $allowedFields) {
+        $this->allowedFields = $allowedFields;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAllowedFields(): array
+    {
+        return $this->allowedFields;
+    }
+
+    /**
+     * @param array $allowedFields
+     */
+    public function setAllowedFields(array $allowedFields): void
+    {
+        $this->allowedFields = $allowedFields;
+    }
+}

--- a/Classes/Event/MaskAllowedFieldsEvent.php
+++ b/Classes/Event/MaskAllowedFieldsEvent.php
@@ -24,6 +24,9 @@ final class MaskAllowedFieldsEvent
      */
     private array $allowedFields;
 
+    /**
+     * @param array<string, list<string>> $allowedFields
+     */
     public function __construct(array $allowedFields)
     {
         $this->allowedFields = $allowedFields;

--- a/Documentation/Guides/Index.rst
+++ b/Documentation/Guides/Index.rst
@@ -18,3 +18,4 @@ functionality.
    DataProcessors
    CropVariants
    RTEConfig
+   UseExistingTCAFields

--- a/Documentation/Guides/UseExistingTCAFields.rst
+++ b/Documentation/Guides/UseExistingTCAFields.rst
@@ -17,20 +17,27 @@ EventListener example
    :caption: EXT:some_extension/Classes/EventListener/MaskAllowedFieldsEventListener.php
 
    <?php
+
    declare(strict_types=1);
 
    namespace VENDOR\SomeExtension\EventListener;
 
    use MASK\Mask\Event\MaskAllowedFieldsEvent;
 
-   class MaskAllowedFieldsEventListener {
-
+   class MaskAllowedFieldsEventListener
+   {
        public function __invoke(MaskAllowedFieldsEvent $event): void
        {
+           // Add field
+           $event->addField('teaser');
+
+           // Remove field
+           $event->addField('imagecols');
+
+           // Get all allowed fields
            $allowedFields = $event->getAllowedFields();
 
-           $allowedFields['tt_content'][] = 'teaser';
-
+           // Do your magic and set allowed fields
            $event->setAllowedFields($allowedFields);
        }
    }

--- a/Documentation/Guides/UseExistingTCAFields.rst
+++ b/Documentation/Guides/UseExistingTCAFields.rst
@@ -1,0 +1,52 @@
+.. include:: ../Includes.txt
+
+.. _use-existing-tca-fields-guide:
+
+=======================
+Use existing TCA fields
+=======================
+
+If you want to use already existing TCA fields, beyond the core fields, you can
+use an EventListener to modify the :php:`$allowedFields` array.
+
+
+EventListener example
+=====================
+
+.. code-block:: php
+   :caption: EXT:some_extension/Classes/EventListener/MaskAllowedFieldsEventListener.php
+
+   <?php
+   declare(strict_types=1);
+
+   namespace VENDOR\SomeExtension\EventListener;
+
+   use MASK\Mask\Event\MaskAllowedFieldsEvent;
+
+   class MaskAllowedFieldsEventListener {
+
+       public function __invoke(MaskAllowedFieldsEvent $event): void
+       {
+           $allowedFields = $event->getAllowedFields();
+
+           $allowedFields['tt_content'][] = 'teaser';
+
+           $event->setAllowedFields($allowedFields);
+       }
+   }
+
+Register EventListener
+======================
+
+.. code-block:: yaml
+   :caption: EXT:some_extension/Configuration/Services.yaml
+
+   services:
+    VENDOR\Extension\EventListener\MaskAllowedFieldsEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'customizeAllowedFields'
+          event: MASK\Mask\Event\MaskAllowedFieldsEvent
+
+
+Have a look at the :ref:`official documentation <t3coreapi:EventDispatcher>` for more information.

--- a/Tests/Unit/Event/MaskAllowedFieldsEventTest.php
+++ b/Tests/Unit/Event/MaskAllowedFieldsEventTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace MASK\Mask\Tests\Unit\Event;
+
+use MASK\Mask\Event\MaskAllowedFieldsEvent;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class MaskAllowedFieldsEventTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function fieldsCanBeFetched(): void
+    {
+        $allowedFields = [
+            'tt_content' => [
+                'foo',
+                'bar',
+            ],
+        ];
+
+        $event = new MaskAllowedFieldsEvent($allowedFields);
+
+        self::assertSame($allowedFields, $event->getAllowedFields());
+    }
+
+    /**
+     * @test
+     */
+    public function fieldsCanBeReplaced(): void
+    {
+        $allowedFields = [
+            'tt_content' => [
+                'foo',
+                'bar',
+            ],
+        ];
+
+        $expected = [
+            'tt_content' => [
+                'oof',
+                'rab',
+            ],
+        ];
+
+        $event = new MaskAllowedFieldsEvent($allowedFields);
+        $event->setAllowedFields($expected);
+
+        self::assertSame($expected, $event->getAllowedFields());
+    }
+
+    /**
+     * @test
+     */
+    public function fieldCanBeAdded(): void
+    {
+        $allowedFields = [
+            'tt_content' => [
+                'foo',
+                'bar',
+            ],
+        ];
+
+        $expected = [
+            'tt_content' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+        ];
+
+        $event = new MaskAllowedFieldsEvent($allowedFields);
+        $event->addField('baz');
+
+        self::assertSame($expected, $event->getAllowedFields());
+    }
+
+    /**
+     * @test
+     */
+    public function fieldCanBeRemoved(): void
+    {
+        $allowedFields = [
+            'tt_content' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+        ];
+
+        $expected = [
+            'tt_content' => [
+                'foo',
+                'baz',
+            ],
+        ];
+
+        $event = new MaskAllowedFieldsEvent($allowedFields);
+        $event->removeField('bar');
+
+        self::assertSame($expected, $event->getAllowedFields());
+    }
+}


### PR DESCRIPTION
With this it is possible to use already existing TCA fields in a Mask content element, by extending the "Core fields" list.

This solves issue #534
