### PR TITLE
[BUGFIX] Prevent error when be:uri.editRecord is used in preview template

### DIFF
--- a/Classes/EventListeners/MaskBackendPreviewEventListener.php
+++ b/Classes/EventListeners/MaskBackendPreviewEventListener.php
@@ -22,11 +22,13 @@ use MASK\Mask\Definition\TableDefinitionCollection;
 use MASK\Mask\Helper\InlineHelper;
 use MASK\Mask\Utility\AffixUtility;
 use MASK\Mask\Utility\TemplatePathUtility;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
 class MaskBackendPreviewEventListener
@@ -84,8 +86,11 @@ class MaskBackendPreviewEventListener
             return;
         }
 
+        $renderingContext = GeneralUtility::makeInstance(RenderingContextFactory::class)->create();
+        $renderingContext->setRequest($this->getRequest());
+
         // Initialize view.
-        $view = GeneralUtility::makeInstance(StandaloneView::class);
+        $view = GeneralUtility::makeInstance(StandaloneView::class, $renderingContext);
         $view->setTemplatePathAndFilename($templatePathAndFilename);
         if (!empty($this->maskExtensionConfiguration['layouts_backend'])) {
             $layoutRootPath = GeneralUtility::getFileAbsFileName($this->maskExtensionConfiguration['layouts_backend']);
@@ -131,5 +136,10 @@ class MaskBackendPreviewEventListener
     protected function getLanguageService(): LanguageService
     {
         return $GLOBALS['LANG'];
+    }
+
+    protected function getRequest(): ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'];
     }
 }


### PR DESCRIPTION
Without the request on the rendering context, the uri.editRecord and link.editRecord ViewHelpers of the backend module are unable to automatically generate a returnUrl.

In the case of uri.editRecord we get an exception in the page module, and with the link.editRecord we'll end up on a blank page, when trying to use the close button to return to the previous page.

---

Not sure if there is a better way to get the TYPO3_REQUEST than through $GLOBALS. Maybe injection?

Also not sure if that perhaps is more of a TYPO3 core bug.

Anyway, I encountered this, because I like to add direct links to nested Content Elements if present right in the Page Module.

An example preview template taken from an Accordion Element:

```html
<f:if condition="{data.tx_mask_accordion}">
    <f:for each="{data.tx_mask_accordion}" as="accordion" iteration="i">
        <div class="well well-sm">
            <div>
                <strong>{accordion.tx_mask_header}</strong>
            </div>
            <f:if condition="{accordion.tx_mask_content}">
                <f:for each="{accordion.tx_mask_content}" as="ce">
                    <f:alias map="{editLink: '{be:uri.editRecord(uid: ce.uid, table: \'tt_content\')}'}">
                        <div>
                            <span title="id={ce.uid}" data-toggle="tooltip" data-placement="top">
                                <core:iconForRecord row="{ce}" table="tt_content"/>
                            </span>
                            <a href="{editLink}" data-toggle="tooltip" data-placement="top" title="id={ce.uid}">
                                <core:icon identifier="actions-open"/>
                            </a>
                            <a href="{editLink}">
                                <f:render section="Label" arguments="{ce: ce}"/>
                            </a>
                        </div>
                    </f:alias>
                </f:for>
            </f:if>
        </div>
    </f:for>
</f:if>
```

If it wasn't the uri-ViewHelper but the link one instead, I'd probably never have noticed this error.