### PR TITLE
[BUGFIX] Add softref-config to link fields

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -457,6 +457,11 @@ class TcaCodeGenerator
                 $field->realTca['config']['softref'] = 'typolink_tag,email[subst],url';
             }
 
+            // InputLink: Add softref
+            if ($fieldType->equals(FieldType::LINK)) {
+                $field->realTca['config']['softref'] = 'typolink';
+            }
+
             // Content: Set foreign_field and default CType in select if restricted.
             if ($fieldType->equals(FieldType::CONTENT)) {
                 $field->realTca['config']['foreign_field'] = 'tx_mask_content_parent_uid';

--- a/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
+++ b/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
@@ -498,14 +498,6 @@ class TcaCodeGeneratorTest extends BaseTestCase
                             ],
                             'key' => 'field_2',
                         ],
-                        'tx_mask_field_3' => [
-                            'config' => [
-                                'type' => 'input',
-                                'renderType' => 'inputLink',
-                                'eval' => 'trim',
-                            ],
-                            'key' => 'field_3',
-                        ],
                     ],
                 ],
             ],
@@ -524,11 +516,27 @@ class TcaCodeGeneratorTest extends BaseTestCase
                     ],
                     'exclude' => 1,
                 ],
-                'tx_mask_field_3' => [
+            ],
+        ];
+
+        yield 'Link fields add softref=typolink' => [
+            'json' => [
+                'tt_content' => [
+                    'tca' => [
+                        'tx_mask_link' => [
+                            'config' => [
+                                'type' => 'link',
+                            ],
+                            'key' => 'link',
+                        ],
+                    ],
+                ],
+            ],
+            'table' => 'tt_content',
+            'expected' => [
+                'tx_mask_link' => [
                     'config' => [
-                        'type' => 'input',
-                        'renderType' => 'inputLink',
-                        'eval' => 'trim',
+                        'type' => 'link',
                         'softref' => 'typolink',
                     ],
                     'exclude' => 1,

--- a/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
+++ b/Tests/Unit/CodeGenerator/TcaCodeGeneratorTest.php
@@ -480,7 +480,7 @@ class TcaCodeGeneratorTest extends BaseTestCase
 
     public function generateFieldsTcaDataProvider(): iterable
     {
-        yield 'Input fields are processd correctly' => [
+        yield 'Input fields are processed correctly' => [
             'json' => [
                 'tt_content' => [
                     'tca' => [
@@ -498,6 +498,14 @@ class TcaCodeGeneratorTest extends BaseTestCase
                             ],
                             'key' => 'field_2',
                         ],
+                        'tx_mask_field_3' => [
+                            'config' => [
+                                'type' => 'input',
+                                'renderType' => 'inputLink',
+                                'eval' => 'trim',
+                            ],
+                            'key' => 'field_3',
+                        ],
                     ],
                 ],
             ],
@@ -513,6 +521,15 @@ class TcaCodeGeneratorTest extends BaseTestCase
                     'config' => [
                         'type' => 'input',
                         'eval' => 'trim',
+                    ],
+                    'exclude' => 1,
+                ],
+                'tx_mask_field_3' => [
+                    'config' => [
+                        'type' => 'input',
+                        'renderType' => 'inputLink',
+                        'eval' => 'trim',
+                        'softref' => 'typolink',
                     ],
                     'exclude' => 1,
                 ],


### PR DESCRIPTION
This allows ext:linkvalidator to properly detect inputLink fields.

Fixes #555