### PR TITLE
[BUGFIX] Show correct field "l10n_parent" in language palette

### DIFF
--- a/Classes/CodeGenerator/TcaCodeGenerator.php
+++ b/Classes/CodeGenerator/TcaCodeGenerator.php
@@ -801,7 +801,7 @@ class TcaCodeGenerator
             'palettes' => [
                 'language' => [
                     'showitem' => '
-                        sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,l18n_parent
+                        sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,l10n_parent
                     ',
                 ],
                 'hidden' => [


### PR DESCRIPTION
The correct name of the "transOrigPointerField" is "l10n_parent", but the palette uses the wrong field name "l18n_parent"