### PR TITLE
enabled required validation for rich text editor fields

### DIFF
--- a/Configuration/Mask/Tabs/richtext.php
+++ b/Configuration/Mask/Tabs/richtext.php
@@ -1,6 +1,11 @@
 <?php
 
 use MASK\Mask\Enumeration\Tab;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+$validation = [
+    (new Typo3Version())->getMajorVersion() > 11 ? 'config.required' : 'config.eval.required' => 6,
+];
 
 return [
     Tab::GENERAL => [
@@ -10,6 +15,9 @@ return [
         [
             'config.default' => 6,
         ],
+    ],
+    Tab::VALIDATION => [
+        $validation,
     ],
     Tab::LOCALIZATION => [
         [


### PR DESCRIPTION
With this commit it is possible to enable or disable the required validation for rich text editor fields.