### PR TITLE
[BUGFIX] Remove application of extendBodytextSearchAndWhere in TYPO3 version 13.4.5 and onwards.

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -21,4 +21,9 @@ $contentColumns = $tcaCodeGenerator->generateFieldsTca('tt_content');
 $tcaCodeGenerator->setInlineTca();
 $tcaCodeGenerator->setElementsTca();
 $GLOBALS['TCA']['tt_content']['ctrl']['searchFields'] = $tcaCodeGenerator->addSearchFields('tt_content');
-$GLOBALS['TCA']['tt_content']['columns']['bodytext']['config']['search']['andWhere'] .= $tcaCodeGenerator->extendBodytextSearchAndWhere();
+$versionString = \TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version();
+if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger($versionString) < 13004005) {
+    // no longer needed in TYPO3 13.4.5 and later
+    // https://review.typo3.org/c/Packages/TYPO3.CMS/+/85489
+    $GLOBALS['TCA']['tt_content']['columns']['bodytext']['config']['search']['andWhere'] .= $tcaCodeGenerator->extendBodytextSearchAndWhere();
+}


### PR DESCRIPTION
Fixes #669

Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/85489