### PR TITLE
[FIX] Make allowed TCA config also possible in array notation.

### DIFF
--- a/Classes/Utility/FieldTypeUtility.php
+++ b/Classes/Utility/FieldTypeUtility.php
@@ -130,7 +130,6 @@ class FieldTypeUtility
         if (is_string($allowedList)) {
             $allowedList = CoreGeneralUtility::trimExplode(',', $allowedList, true);
         }
-        $allowedList = CoreGeneralUtility::trimExplode(',', $allowedList, true);
         $onlineMediaHelperRegistry = CoreGeneralUtility::makeInstance(OnlineMediaHelperRegistry::class);
         $onlineMediaTypes = $onlineMediaHelperRegistry->getSupportedFileExtensions();
         if (!empty(array_intersect($allowedList, $onlineMediaTypes))) {

--- a/Classes/Utility/FieldTypeUtility.php
+++ b/Classes/Utility/FieldTypeUtility.php
@@ -127,6 +127,9 @@ class FieldTypeUtility
     {
         // Check if the allowed list contains online media types.
         $allowedList = $tca['config']['allowed'] ?? '';
+        if (is_string($allowedList)) {
+            $allowedList = CoreGeneralUtility::trimExplode(',', $allowedList, true);
+        }
         $allowedList = CoreGeneralUtility::trimExplode(',', $allowedList, true);
         $onlineMediaHelperRegistry = CoreGeneralUtility::makeInstance(OnlineMediaHelperRegistry::class);
         $onlineMediaTypes = $onlineMediaHelperRegistry->getSupportedFileExtensions();


### PR DESCRIPTION
Ensure that isMediaType is capable of managing the `allowed` configuration of a media field in array and string notation to prevent exceptions for type errors.